### PR TITLE
feat: switch to cerberus theme, add dark mode toggle

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -4,6 +4,8 @@
 
 @import "@skeletonlabs/skeleton";
 @import "@skeletonlabs/skeleton/optional/presets";
-@import "@skeletonlabs/skeleton/themes/catppuccin";
+@import "@skeletonlabs/skeleton/themes/cerberus";
 
 @source '../node_modules/@skeletonlabs/skeleton-svelte/dist';
+
+@custom-variant dark (&:where([data-mode=dark], [data-mode=dark] *));

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="catppuccin">
+<html lang="en" data-theme="cerberus">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.svg" />

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -1,16 +1,21 @@
 <script lang="ts">
+  import ThemeButton from "$lib/components/ThemeButton.svelte";
+
   import { Github } from "@lucide/svelte";
   import { AppBar } from "@skeletonlabs/skeleton-svelte";
 </script>
 
 <AppBar>
   {#snippet lead()}
-    <a href="/" class="h1 text-xl">Travel Log</a>
+    <a href="/" class="anchor font-bold text-xl">Travel Log</a>
   {/snippet}
   {#snippet trail()}
-    <button type="button" class="btn preset-filled-primary-500">
-      Sign In With Github
-      <Github size={20} />
-    </button>
+    <div class="flex items-center gap-3">
+      <ThemeButton />
+      <button type="button" class="btn preset-filled-primary-500">
+        <span class="text-white"> Sign In With Github </span>
+        <Github size={20} class="text-white" />
+      </button>
+    </div>
   {/snippet}
 </AppBar>

--- a/src/lib/components/ThemeButton.svelte
+++ b/src/lib/components/ThemeButton.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { Moon, Sun } from "@lucide/svelte";
+
+  let isLight = $state(false);
+
+  $effect(() => {
+    const mode = localStorage.getItem("mode") ?? "dark";
+    isLight = mode === "light";
+  });
+
+  function toggleTheme(event: Event) {
+    const input = event.target as HTMLInputElement;
+
+    const mode = input.checked ? "light" : "dark";
+    document.documentElement.dataset.mode = mode;
+    localStorage.setItem("mode", mode);
+
+    isLight = input.checked;
+  }
+</script>
+
+<svelte:head>
+  <script>
+    const mode = localStorage.getItem("mode") ?? "dark";
+    document.documentElement.dataset.mode = mode;
+    localStorage.setItem("mode", mode);
+  </script>
+</svelte:head>
+
+<label for="color-mode" class="swap">
+  <input
+    id="color-mode"
+    type="checkbox"
+    checked={isLight}
+    onchange={toggleTheme}
+  />
+  <button title="moon icon" aria-label="moonicon" class="swap-on">
+    <Moon size={24} />
+  </button>
+  <button class="swap-off" title="sun icon" aria-label="sun icon">
+    <Sun size={24} />
+  </button>
+</label>
+
+<style>
+  .swap {
+    position: relative;
+    width: 24px;
+    height: 24px;
+  }
+
+  .swap input {
+    appearance: none;
+    position: absolute;
+    inset: 0;
+    cursor: pointer;
+    z-index: 2;
+  }
+
+  .swap-on {
+    z-index: 1;
+    position: absolute;
+    opacity: 0;
+    transform: rotate(-50deg);
+    transition:
+      transform 0.4s ease-in-out,
+      opacity 0.1s ease-in 0.25s;
+  }
+
+  .swap-off {
+    position: absolute;
+    opacity: 1;
+    transform: rotate(0deg);
+    transition:
+      transform 0.4s ease-in-out,
+      opacity 0.2s ease-in 0.2s;
+  }
+
+  .swap input:checked ~ .swap-on {
+    opacity: 1;
+    transform: rotate(0deg);
+  }
+
+  .swap input:checked ~ .swap-off {
+    transform: rotate(50deg);
+    opacity: 0;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
     <div
       class="p-6 min-h-96 text-center flex flex-col justify-center max-w-md gap-8"
     >
-      <h2 class="h2">Travel Log</h2>
+      <h2 class="h1">Travel Log</h2>
 
       <p>
         Keep track of your travels and adventures. Add locations, photos, and
@@ -16,10 +16,18 @@
 
       <div>
         <button type="button" class="btn preset-filled-primary-500">
-          Sign In With Github
-          <Github size={20} />
+          <span class="text-white"> Sign In With Github </span>
+          <Github size={20} class="text-white" />
         </button>
       </div>
     </div>
   </div>
 </main>
+
+<svelte:head>
+  <title>Sveltekit Travel Log</title>
+  <meta
+    name="description"
+    content="Keep track of your travels and adventures. Add locations, photos, and notes to create a digital journal of your journeys"
+  />
+</svelte:head>


### PR DESCRIPTION
fix #12 

- Changed theme from catppuccin to cerberus in app.css and app.html
- Added ThemeButton component for toggling between light and dark modes.
- updated Navbar to include ThemeButton and improved Github sign-in button styling.
- Improved homepage heading and Gihub button styles.
- Added meta tags for SEO in homepage.