### PR TITLE
refator: move session to event.locals

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,13 +1,19 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
+//
+
+import type { Session } from "./lib/types";
+
 declare global {
   namespace App {
     // interface Error {}
-    // interface Locals {}
+    interface Locals {
+      session: Session;
+    }
     // interface PageData {}
     // interface PageState {}
     // interface Platform {}
   }
 }
 
-export {};
+export { };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,11 +6,13 @@ import { redirect } from "@sveltejs/kit";
 import { svelteKitHandler } from "better-auth/svelte-kit";
 
 export const handle: Handle = async ({ event, resolve }) => {
-  if (event.url.pathname.startsWith("/dashboard")) {
-    const session = await auth.api.getSession({
-      headers: event.request.headers,
-    });
+  const session = await auth.api.getSession({
+    headers: event.request.headers,
+  });
 
+  event.locals.session = session;
+
+  if (event.url.pathname.startsWith("/dashboard")) {
     if (!session?.user) {
       redirect(302, "/");
     }

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,13 +1,7 @@
 import type { LayoutServerLoad } from "./$types";
 
-import { auth } from "$lib/server/auth";
-
-export const load: LayoutServerLoad = async ({ request }) => {
-  const session = await auth.api.getSession({
-    headers: request.headers,
-  });
-
+export const load: LayoutServerLoad = async ({ locals }) => {
   return {
-    session,
+    session: locals.session,
   };
 };


### PR DESCRIPTION
Move session retrieval to `event.locals` in hooks and update layout server load to use `locals.session.