### PR TITLE
refactor: extract insertLocationto query module

### DIFF
--- a/src/lib/server/db/queries/location.ts
+++ b/src/lib/server/db/queries/location.ts
@@ -1,0 +1,15 @@
+import type { LocationInsertData } from "$lib/types";
+
+import { location } from "$lib/schema";
+
+import db from "$lib/server/db";
+
+export async function insertLocation(data: LocationInsertData, slug: string, userId: number) {
+  const result = await db.insert(location).values({
+    ...data,
+    slug,
+    userId,
+  }).returning();
+
+  return result[0];
+}

--- a/src/routes/api/locations/+server.ts
+++ b/src/routes/api/locations/+server.ts
@@ -1,16 +1,14 @@
 import type { DrizzleQueryError } from "drizzle-orm/errors";
 
-import { location } from "$lib/schema";
-
 import { LocationInsertSchema } from "$lib/schema/location";
 import { AuthenticatedRequestHandler } from "$lib/server/auth-request-handler";
 
-import db from "$lib/server/db";
-
+import { insertLocation } from "$lib/server/db/queries/location";
 import { formatValibotIssues } from "$lib/utils/valibot-format-error";
-import { json } from "@sveltejs/kit";
 
+import { json } from "@sveltejs/kit";
 import slugify from "slug";
+
 import * as v from "valibot";
 
 export const POST = AuthenticatedRequestHandler(async ({ request, locals }) => {
@@ -29,11 +27,7 @@ export const POST = AuthenticatedRequestHandler(async ({ request, locals }) => {
   const userId = Number(locals.session?.user.id);
 
   try {
-    const [created] = await db.insert(location).values({
-      ...validatedData,
-      slug,
-      userId,
-    }).returning();
+    const created = await insertLocation(validatedData, slug, userId);
 
     return json(created, { status: 201 });
   } catch (e) {


### PR DESCRIPTION
Fix #23 

Move the location insertion logic from the API route to a dedicated query function in the db/queries module. This improves code reuse and maintainability by centralizing database operations

