### PR TITLE
feat: add marker on map click event

### DIFF
--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { LngLatLike } from "maplibre-gl";
+  import type { LngLatLike, MapMouseEvent } from "maplibre-gl";
   import { CENTER_BRASIL, ZOOM_MAP } from "$lib/constants";
 
   import { getMapContext } from "$lib/context/map";
@@ -36,9 +36,16 @@
       });
     }
   });
+
+  const handleMapClick = (e: MapMouseEvent) => {
+    if (mapStore.showAddMarker) {
+      mapStore.addMarker = e.lngLat;
+    }
+  };
 </script>
 
 <MapLibre
+  onclick={handleMapClick}
   bind:map={mapStore.map}
   center={CENTER_BRASIL as LngLatLike}
   zoom={ZOOM_MAP}


### PR DESCRIPTION
Add a click handler to the MapLibre component that sets the marker position in the map store when map is clicked. This eenables users to add a marker by click on the map.