### PR TITLE
chore: add CLAUDE.md, code-reviewer skill, and fix Nominatim typo

### DIFF
--- a/.claude/skills/code-reviewer/SKILL.md
+++ b/.claude/skills/code-reviewer/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: code-reviewer
+description: Senior reviewer
+arguments: [file]
+model: sonnet
+disable-model-invocation: true
+---
+
+## Role
+
+You are a Senior Software Engineer specializing in security, performance, and clean code.
+
+## Execution Rules
+
+1. **Analyze** the provided $file content for logical bugs.
+2. **Identify** "Code Smells" or anti-patterns.
+3. **Suggest** specific optimizations for the language used.
+4. **Format** your output with a "Issues" section and a "Proposed Solution" code block.
+
+# Context
+
+Review this current $file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Development (starts both the local Turso DB and Vite dev server concurrently)
+pnpm dev
+
+# Start only the local Turso SQLite server
+pnpm dev:db
+
+# Type checking
+pnpm check
+pnpm check:watch
+
+# Linting
+pnpm lint
+pnpm lint:fix
+
+# Database
+pnpm db:generate   # generate migrations from schema changes
+pnpm db:migrate    # apply migrations
+pnpm db:studio     # open Drizzle Studio
+
+# Build & preview
+pnpm build
+pnpm preview
+```
+
+There are no automated tests. Use `pnpm check` for type safety.
+
+## Environment Variables
+
+Copy `.env.example` to `.env`. Required vars:
+
+| Variable                                    | Purpose                                         |
+| ------------------------------------------- | ----------------------------------------------- |
+| `TURSO_DATABASE_URL`                        | `http://127.0.0.1:8080` for local dev           |
+| `TURSO_AUTH_TOKEN`                          | Leave empty for local dev                       |
+| `BETTER_AUTH_SECRET`                        | Random secret for better-auth                   |
+| `BETTER_AUTH_URL`                           | `http://localhost:5173` for local dev           |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | GitHub OAuth app credentials                    |
+| `VERCEL_URL`                                | Set to the deployed Vercel domain in production |
+
+## Architecture
+
+### Stack
+
+- **SvelteKit** (Svelte 5 with runes) — full-stack framework
+- **better-auth** — authentication with GitHub OAuth as the only provider
+- **Drizzle ORM** + **Turso (libSQL/SQLite)** — database; local dev uses `turso dev --db-file local.db`
+- **MapLibre GL** + **svelte-maplibre-gl** — interactive maps
+- **TanStack Query** — client-side mutation state
+- **sveltekit-superforms** + **valibot** — form validation (client + server)
+- **Skeleton UI** — component library (Navigation, modals, etc.)
+- **Tailwind CSS v4** — styling
+- **ky** — HTTP client for API calls from the browser
+
+### Auth flow
+
+`hooks.server.ts` runs on every request: it calls `auth.api.getSession()`, attaches the result to `event.locals.session`, and redirects unauthenticated users away from `/dashboard/**`. The better-auth SvelteKit handler is mounted at the end of the hook.
+
+The client-side `authClient` (`src/lib/aut-client.ts`) drives `signIn.social({ provider: "github" })` and `signOut()`.
+
+All API route handlers are wrapped with `AuthenticatedRequestHandler` (`src/lib/server/auth-request-handler.ts`), which returns 401 when `locals.session` is absent.
+
+### Database & schema
+
+Schemas live in `src/lib/schema/` and export both Drizzle table definitions and valibot insert/select schemas (via `drizzle-valibot`). The main tables are `location` and `locationLog` (with `locationLogImage` planned). The DB client in `src/lib/server/db/index.ts` uses `snake_case` column mapping.
+
+Migrations are generated and applied with `drizzle-kit` and stored in `src/lib/server/db/migrations/`.
+
+### API routes
+
+- `GET /api/locations` — fetch the authenticated user's locations
+- `POST /api/locations` — create a location; handled by the `InsertLocation` service class which slugifies the name and retries on slug collisions (up to 3 attempts)
+- `GET /api/search?q=...` — proxy to Nominatim (OpenStreetMap geocoder) for location search
+
+### State management pattern
+
+Global state uses **Svelte 5 context + reactive stores**. The dashboard layout (`src/routes/dashboard/+layout.svelte`) initializes two context stores:
+
+- `locationContext` — a getter `() => Location[]` derived from server-loaded data
+- `mapStore` — a `$state` object wrapping MapLibre GL state (map instance, markers, selected point, fly-to helpers); created by `createMapStore()` and depends on `locationContext`
+
+Child routes access these via `getLocationContext()` / `getMapContext()`.
+
+### Result type
+
+Server service functions return `Response<T, E>` (defined in `src/lib/server/utils/http-response.ts`): `{ success: true; value: T } | { success: false; value: E }`. Prefer this over throwing in service layer code.
+
+### Routing structure
+
+```
+/                        — landing / sign-in
+/dashboard               — location list + map
+/dashboard/add           — add location form with draggable marker and Nominatim search
+/dashboard/location/[slug] — location detail (stub)
+/sign-out                — triggers signOut
+/error                   — auth error redirect target
+/api/locations           — REST endpoint
+/api/search              — Nominatim proxy
+```
+
+### ESLint
+
+Uses `@antfu/eslint-config` with Svelte + TypeScript support. Double quotes, semicolons. Husky runs `lint-staged` (full lint) on pre-commit.

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,3 @@
 export const CENTER_BRASIL = [-54.3879654, -15.0771918];
 export const ZOOM_MAP = 3.0;
-export const NOMINATIN_URL = "https://nominatim.openstreetmap.org";
+export const NOMINATIM_URL = "https://nominatim.openstreetmap.org";

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -1,5 +1,5 @@
 import type { SearchResult } from "$lib/types";
-import { NOMINATIN_URL } from "$lib/constants";
+import { NOMINATIM_URL } from "$lib/constants";
 import { AuthenticatedRequestHandler } from "$lib/server/auth-request-handler";
 
 import { formatValibotIssues } from "$lib/utils/valibot-format-error";
@@ -12,39 +12,35 @@ const schema = v.object({
   q: v.pipe(
     v.string(),
     v.minLength(1),
+    v.maxLength(200),
   ),
 });
 
 export const GET = AuthenticatedRequestHandler(async ({ url, fetch }) => {
   const q = url.searchParams.get("q");
 
-  const result = v.safeParse(schema, {
-    q,
-  });
+  const result = v.safeParse(schema, { q });
 
   if (!result.success) {
-    return json(formatValibotIssues(result.issues), {
-      status: 400,
-    });
+    return json(formatValibotIssues(result.issues), { status: 400 });
   }
 
-  const validResult = result.output;
+  const params = new URLSearchParams({
+    q: result.output.q,
+    format: "json",
+  });
 
-  const response = await fetch(`${NOMINATIN_URL}/search?q=${validResult.q}&format=json`, {
+  const response = await fetch(`${NOMINATIM_URL}/search?${params}`, {
     headers: {
       "User-Agent": "sveltekit-travel-log",
     },
   });
 
   if (!response.ok) {
-    return json({
-      msg: "failed to search for location",
-    });
+    return json({ message: "upstream geocoder request failed" }, { status: 502 });
   }
-  const data = await response.json();
-  const locations = data as SearchResult[];
 
-  return json({
-    locations,
-  });
+  const locations = (await response.json()) as SearchResult[];
+
+  return json({ locations });
 });


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with full architecture docs and dev commands for Claude Code
- Add `.claude/skills/code-reviewer` skill definition for in-repo code review
- Fix `NOMINATIN_URL` typo → `NOMINATIM_URL` in `src/lib/constants.ts` and the search route
- Tighten `GET /api/search`: add `maxLength(200)` validation, use `URLSearchParams` to safely build the Nominatim URL, return 502 on upstream failure

## Test plan

- [ ] `pnpm check` passes with no type errors
- [ ] Location search still works on `/dashboard/add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)