### PR TITLE
fix: Map.svelte marker hover and init guard

### DIFF
--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -18,11 +18,14 @@
 
   const themeStore = getThemeContext();
   const mapStore = getMapContext();
+  let mapIsLoaded = $state(false);
 
   const theme = $derived(themeStore().theme);
 
   $effect(() => {
-    mapStore.initMap();
+    if (mapIsLoaded) {
+      mapStore.initMap();
+    }
   });
 
   $effect(() => {
@@ -45,6 +48,9 @@
 </script>
 
 <MapLibre
+  onload={() => {
+    mapIsLoaded = true;
+  }}
   onclick={handleMapClick}
   bind:map={mapStore.map}
   center={CENTER_BRASIL as LngLatLike}
@@ -74,9 +80,12 @@
       {#snippet content()}
         <MapPin
           size={32}
-          class={[isHovered ? "fill-primary-500" : "fill-tertiary-500"]}
+          class={isHovered ? "fill-primary-500" : "fill-tertiary-500"}
           onmouseenter={() => {
             mapStore.selectedPoint = point;
+          }}
+          onmouseleave={() => {
+            mapStore.selectedPoint = null;
           }}
         />
       {/snippet}


### PR DESCRIPTION
## Summary

- Adds `onmouseleave` to reset `selectedPoint` so popups no longer stay open after the cursor leaves a marker
- Guards `initMap` behind a `mapIsLoaded` flag so it only runs once the MapLibre instance is ready
- Removes redundant array wrapper from the `class` ternary on `MapPin`

## Test plan

- [x] Hover over a map marker — popup opens and pin highlights
- [x] Move mouse away — popup closes and pin returns to default color
- [x] Add a new location and verify it appears on the map without requiring a page reload
- [x] Toggle dark/light theme and confirm the map style switches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)