### PR TITLE
feat: migrate to TanStack Form and extract LocationFormBase component

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@libsql/client": "^0.15.9",
     "@lucide/svelte": "^0.525.0",
+    "@tanstack/svelte-form": "^1.32.0",
     "@tanstack/svelte-query": "^5.85.5",
     "better-auth": "^1.2.12",
     "bits-ui": "^2.18.1",
@@ -52,7 +53,6 @@
     "husky": "^9.1.7",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
-    "sveltekit-superforms": "^2.27.1",
     "tailwindcss": "^4.0.0",
     "tsx": "^4.20.3",
     "typescript": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@lucide/svelte':
         specifier: ^0.525.0
         version: 0.525.0(svelte@5.35.2)
+      '@tanstack/svelte-form':
+        specifier: ^1.32.0
+        version: 1.32.0(svelte@5.35.2)
       '@tanstack/svelte-query':
         specifier: ^5.85.5
         version: 5.85.5(svelte@5.35.2)
@@ -105,9 +108,6 @@ importers:
       svelte-check:
         specifier: ^4.0.0
         version: 4.2.2(picomatch@4.0.2)(svelte@5.35.2)(typescript@5.8.3)
-      sveltekit-superforms:
-        specifier: ^2.27.1
-        version: 2.27.1(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.35.2)(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.35.2)(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.5)(svelte@5.35.2)(typescript@5.8.3)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.11
@@ -182,12 +182,6 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@ark/schema@0.46.0':
-    resolution: {integrity: sha512-c2UQdKgP2eqqDArfBqQIJppxJHvNNXuQPeuSPlDML4rjw+f1cu0qAlzOG4b8ujgm9ctIDWwhpyw6gjG5ledIVQ==}
-
-  '@ark/util@0.46.0':
-    resolution: {integrity: sha512-JPy/NGWn/lvf1WmGCPw2VGpBg5utZraE84I7wli18EDF3p3zc/e9WolT35tINeZO3l7C77SjqRJeAUoT0CvMRg==}
-
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -204,10 +198,6 @@ packages:
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/runtime@7.28.2':
-    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -604,9 +594,6 @@ packages:
     resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@exodus/schemasafe@1.3.0':
-    resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
-
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -615,16 +602,6 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@gcornut/valibot-json-schema@0.42.0':
-    resolution: {integrity: sha512-4Et4AN6wmqeA0PfU5Clkv/IS27wiefsWf6TemAZrb75uzkClYEFavim7SboeKwbll9Nbsn2Iv0LT/HS5H7orZg==}
-    hasBin: true
-
-  '@hapi/hoek@9.3.0':
-    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
-
-  '@hapi/topo@5.1.0':
-    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
@@ -820,9 +797,6 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@poppinss/macroable@1.0.5':
-    resolution: {integrity: sha512-6u61y1HHd090MEk1Av0/1btDmm2Hh/+XoJj+HgFYRh9koUPI822ybJbwLHuqjLNCiY+o1gRykg2igEqOf/VBZw==}
-
   '@rollup/rollup-android-arm-eabi@4.44.2':
     resolution: {integrity: sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==}
     cpu: [arm]
@@ -923,24 +897,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sideway/address@4.1.5':
-    resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
-
-  '@sideway/formula@3.0.1':
-    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
-
-  '@sideway/pinpoint@2.0.0':
-    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
-
   '@simplewebauthn/browser@13.1.2':
     resolution: {integrity: sha512-aZnW0KawAM83fSBUgglP5WofbrLbLyr7CoPqYr66Eppm7zO86YX6rrCjRB3hQKPrL7ATvY4FVXlykZ6w6FwYYw==}
 
   '@simplewebauthn/server@13.1.2':
     resolution: {integrity: sha512-VwoDfvLXSCaRiD+xCIuyslU0HLxVggeE5BL06+GbsP2l1fGf5op8e0c3ZtKoi+vSg1q4ikjtAghC23ze2Q3H9g==}
     engines: {node: '>=20.0.0'}
-
-  '@sinclair/typebox@0.34.38':
-    resolution: {integrity: sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==}
 
   '@skeletonlabs/skeleton-svelte@1.2.4':
     resolution: {integrity: sha512-0rQ/7Dx8dqdBNJ6/qQa69iMYwMdRG4RJTg35CwPU6CsKE6Ee9fWNd+bWriLFsyYaOTNNTgP8UeXlWaTowr0OSg==}
@@ -951,9 +913,6 @@ packages:
     resolution: {integrity: sha512-sp7+FZN9bYR4ULtVop39bZ7a7l9tbu/VCwlgJxh2YQ9hrx85Rh0If+VYajPL18eD4CsnIOmsltEspBuRSjQYVw==}
     peerDependencies:
       tailwindcss: ^4.0.0
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@stylistic/eslint-plugin@5.1.0':
     resolution: {integrity: sha512-TJRJul4u/lmry5N/kyCU+7RWWOk0wyXN+BncRlDYBqpLFnzXkd7QGVfN7KewarFIXv0IX0jSF/Ksu7aHWEDeuw==}
@@ -1093,13 +1052,38 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@tanstack/devtools-event-client@0.4.3':
+    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@tanstack/form-core@1.32.0':
+    resolution: {integrity: sha512-Tn5VRDSjyqjmaet2tJMuEWDRFyrCaon03vxXPlSSaiSs6C/N7lCIwGCXJbZXEUq1kTj8jYN9qyXHbsz4LQHcow==}
+
+  '@tanstack/pacer-lite@0.1.1':
+    resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
+    engines: {node: '>=18'}
+
   '@tanstack/query-core@5.85.5':
     resolution: {integrity: sha512-KO0WTob4JEApv69iYp1eGvfMSUkgw//IpMnq+//cORBzXf0smyRwPLrUvEe5qtAEGjwZTXrjxg+oJNP/C00t6w==}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/svelte-form@1.32.0':
+    resolution: {integrity: sha512-oFo+heA0YPTtVPLdt2/ftobmPS+ckIgMwBww/vYuIcySFFMaQXnFdJGVr10SLbWWJR5l/NOUwiLs/BTgyEZ2VQ==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   '@tanstack/svelte-query@5.85.5':
     resolution: {integrity: sha512-/oiyfVh0B+8b7DiGJI6s5ua8cU1wvMw+0yscs+XmQejQ29ngBlRAjkh2PEYif2VO3BK1FxGa2CdiKt62xRHywA==}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0 || ^5.0.0
+
+  '@tanstack/svelte-store@0.10.3':
+    resolution: {integrity: sha512-9gM4mc+a42PQtydeFvq+BYqO1NYp85YocKFybV1mis9kCg8XbpwVfwbTkiiKDPdtnSMCc5nUqzcxmvvNJAVF8A==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -1137,27 +1121,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/validator@13.15.2':
-    resolution: {integrity: sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==}
-
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@typeschema/class-validator@0.3.0':
-    resolution: {integrity: sha512-OJSFeZDIQ8EK1HTljKLT5CItM2wsbgczLN8tMEfz3I1Lmhc5TBfkZ0eikFzUC16tI3d1Nag7um6TfCgp2I2Bww==}
-    peerDependencies:
-      class-validator: ^0.14.1
-    peerDependenciesMeta:
-      class-validator:
-        optional: true
-
-  '@typeschema/core@0.14.0':
-    resolution: {integrity: sha512-Ia6PtZHcL3KqsAWXjMi5xIyZ7XMH4aSnOQes8mfMLx+wGFGtGRNlwe6Y7cYvX+WfNK67OL0/HSe9t8QDygV0/w==}
-    peerDependencies:
-      '@types/json-schema': ^7.0.15
-    peerDependenciesMeta:
-      '@types/json-schema':
-        optional: true
 
   '@typescript-eslint/eslint-plugin@8.35.1':
     resolution: {integrity: sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==}
@@ -1217,14 +1182,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.35.1':
     resolution: {integrity: sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@vinejs/compiler@3.0.0':
-    resolution: {integrity: sha512-v9Lsv59nR56+bmy2p0+czjZxsLHwaibJ+SV5iK9JJfehlJMa501jUJQqqz4X/OqKXrxtE3uTQmSqjUqzF3B2mw==}
-    engines: {node: '>=18.0.0'}
-
-  '@vinejs/vine@3.0.1':
-    resolution: {integrity: sha512-ZtvYkYpZOYdvbws3uaOAvTFuvFXoQGAtmzeiXu+XSMGxi5GVsODpoI9Xu9TplEMuD/5fmAtBbKb9cQHkWkLXDQ==}
-    engines: {node: '>=18.16.0'}
 
   '@vitest/eslint-plugin@1.3.4':
     resolution: {integrity: sha512-EOg8d0jn3BAiKnR55WkFxmxfWA3nmzrbIIuOXyTe6A72duryNgyU+bdBEauA97Aab3ho9kLmAwgPX63Ckj4QEg==}
@@ -1405,9 +1362,6 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
-  arktype@2.1.20:
-    resolution: {integrity: sha512-IZCEEXaJ8g+Ijd59WtSYwtjnqXiwM8sWQ5EjGamcto7+HVN9eK0C4p0zDlCuAwWhpqr6fIBkxPuYDl4/Mcj/+Q==}
-
   asn1js@3.0.6:
     resolution: {integrity: sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==}
     engines: {node: '>=12.0.0'}
@@ -1465,10 +1419,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camelcase@8.0.0:
-    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
-    engines: {node: '>=16'}
-
   caniuse-lite@1.0.30001726:
     resolution: {integrity: sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==}
 
@@ -1497,9 +1447,6 @@ packages:
   ci-info@4.2.0:
     resolution: {integrity: sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==}
     engines: {node: '>=8'}
-
-  class-validator@0.14.2:
-    resolution: {integrity: sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==}
 
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
@@ -1576,9 +1523,6 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  dayjs@1.11.13:
-    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
-
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
@@ -1618,9 +1562,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   drizzle-kit@0.31.4:
     resolution: {integrity: sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==}
@@ -1727,9 +1668,6 @@ packages:
   earcut@3.0.2:
     resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
 
-  effect@3.17.7:
-    resolution: {integrity: sha512-dpt0ONUn3zzAuul6k4nC/coTTw27AL5nhkORXgTi6NfMPzqWYa1M05oKmOMTxpVSTKepqXVcW9vIwkuaaqx9zA==}
-
   electron-to-chromium@1.5.179:
     resolution: {integrity: sha512-UWKi/EbBopgfFsc5k61wFpV7WrnnSlSzW/e2XcBmS6qKYTivZlLtoll5/rdqRTxGglGHkmkW0j0pFNJG10EUIQ==}
 
@@ -1755,12 +1693,6 @@ packages:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
       esbuild: '>=0.12 <1'
-
-  esbuild-runner@2.2.2:
-    resolution: {integrity: sha512-fRFVXcmYVmSmtYm2mL8RlUASt2TDkGh3uRcvHFOKNr/T58VrfVeKD9uT9nlgxk96u0LS0ehS/GY7Da/bXWKkhw==}
-    hasBin: true
-    peerDependencies:
-      esbuild: '*'
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -2017,10 +1949,6 @@ packages:
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
-  fast-check@3.23.2:
-    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
-    engines: {node: '>=8.0.0'}
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2211,9 +2139,6 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
-  joi@17.13.3:
-    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
-
   jose@6.0.11:
     resolution: {integrity: sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==}
 
@@ -2240,10 +2165,6 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -2282,9 +2203,6 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
-
-  libphonenumber-js@1.12.10:
-    resolution: {integrity: sha512-E91vHJD61jekHHR/RF/E83T/CMoaLXT7cwYA75T4gim4FZjnM6hbJjVIGg7chqlSqRsSvQ3izGmOjHy1SQzcGQ==}
 
   libsql@0.5.13:
     resolution: {integrity: sha512-5Bwoa/CqzgkTwySgqHA5TsaUDRrdLIbdM4egdPcaAnqO3aC+qAgS6BwdzuZwARA5digXwiskogZ8H7Yy4XfdOg==}
@@ -2448,9 +2366,6 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
-
-  memoize-weak@1.0.2:
-    resolution: {integrity: sha512-gj39xkrjEw7nCn4nJ1M5ms6+MyMlyiGmttzsqAUsAKn6bYKwuTHh/AO3cKPF8IBrTIYTxb0wWXFs3E//Y8VoWQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2641,10 +2556,6 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  normalize-url@8.0.2:
-    resolution: {integrity: sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==}
-    engines: {node: '>=14.16'}
-
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -2784,18 +2695,12 @@ packages:
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
-  property-expr@2.0.6:
-    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
-
   protocol-buffers-schema@3.6.0:
     resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  pure-rand@6.1.0:
-    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -2989,10 +2894,6 @@ packages:
   supercluster@8.0.1:
     resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
 
-  superstruct@2.0.2:
-    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
-    engines: {node: '>=14.0.0'}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3034,12 +2935,6 @@ packages:
     resolution: {integrity: sha512-uW/rRXYrhZ7Dh4UQNZ0t+oVGL1dEM+95GavCO8afAk1IY2cPq9BcZv9C3um5aLIya2y8lIeLPxLII9ASGg9Dzw==}
     engines: {node: '>=18'}
 
-  sveltekit-superforms@2.27.1:
-    resolution: {integrity: sha512-cvq2AevkZ0Zrk0w0gNM3kjcnJMtJ0jzu+2zqDoM9a+lZa+8bGpNl4YqxVkemiJNkGnFgNC8xr5xF5BlMzjookQ==}
-    peerDependencies:
-      '@sveltejs/kit': 1.x || 2.x
-      svelte: 3.x || 4.x || >=5.0.0-next.51
-
   synckit@0.11.8:
     resolution: {integrity: sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -3062,9 +2957,6 @@ packages:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
 
-  tiny-case@1.0.3:
-    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
-
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
 
@@ -3083,9 +2975,6 @@ packages:
     resolution: {integrity: sha512-khrZo4buq4qVmsGzS5yQjKe/WsFvV8fGfOjDQN0q4iy9FjRfPWRgTFrU8u1R2iu/SfWLhY9WnCi4Jhdrcbtg+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  toposort@2.0.2:
-    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
-
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -3093,9 +2982,6 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
-
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -3108,13 +2994,6 @@ packages:
     peerDependencies:
       typescript: '>=4.0.0'
 
-  ts-deepmerge@7.0.3:
-    resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==}
-    engines: {node: '>=14.13.1'}
-
-  tslib@2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3126,10 +3005,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -3169,14 +3044,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  valibot@0.42.1:
-    resolution: {integrity: sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw==}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   valibot@1.1.0:
     resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
     peerDependencies:
@@ -3184,10 +3051,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  validator@13.15.15:
-    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
-    engines: {node: '>= 0.10'}
 
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
@@ -3313,16 +3176,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  yup@1.7.0:
-    resolution: {integrity: sha512-VJce62dBd+JQvoc+fCVq+KZfPHr+hXaxCcVgotfwWvlR0Ja3ffYKaJBT8rptPOSKOGJDCUnW2C2JWpud7aRP6Q==}
-
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
-
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
-    peerDependencies:
-      zod: ^3.24.1
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3395,14 +3250,6 @@ snapshots:
       package-manager-detector: 1.3.0
       tinyexec: 1.0.1
 
-  '@ark/schema@0.46.0':
-    dependencies:
-      '@ark/util': 0.46.0
-    optional: true
-
-  '@ark/util@0.46.0':
-    optional: true
-
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
@@ -3412,9 +3259,6 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/runtime@7.28.2':
-    optional: true
 
   '@babel/types@7.29.0':
     dependencies:
@@ -3694,9 +3538,6 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
-  '@exodus/schemasafe@1.3.0':
-    optional: true
-
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -3707,25 +3548,6 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
-
-  '@gcornut/valibot-json-schema@0.42.0(esbuild@0.25.5)(typescript@5.8.3)':
-    dependencies:
-      valibot: 0.42.1(typescript@5.8.3)
-    optionalDependencies:
-      '@types/json-schema': 7.0.15
-      esbuild-runner: 2.2.2(esbuild@0.25.5)
-    transitivePeerDependencies:
-      - esbuild
-      - typescript
-    optional: true
-
-  '@hapi/hoek@9.3.0':
-    optional: true
-
-  '@hapi/topo@5.1.0':
-    dependencies:
-      '@hapi/hoek': 9.3.0
-    optional: true
 
   '@hexagon/base64@1.1.28': {}
 
@@ -3932,9 +3754,6 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@poppinss/macroable@1.0.5':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.44.2':
     optional: true
 
@@ -3995,17 +3814,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.44.2':
     optional: true
 
-  '@sideway/address@4.1.5':
-    dependencies:
-      '@hapi/hoek': 9.3.0
-    optional: true
-
-  '@sideway/formula@3.0.1':
-    optional: true
-
-  '@sideway/pinpoint@2.0.0':
-    optional: true
-
   '@simplewebauthn/browser@13.1.2': {}
 
   '@simplewebauthn/server@13.1.2':
@@ -4017,9 +3825,6 @@ snapshots:
       '@peculiar/asn1-rsa': 2.3.15
       '@peculiar/asn1-schema': 2.3.15
       '@peculiar/asn1-x509': 2.3.15
-
-  '@sinclair/typebox@0.34.38':
-    optional: true
 
   '@skeletonlabs/skeleton-svelte@1.2.4(svelte@5.35.2)':
     dependencies:
@@ -4045,9 +3850,6 @@ snapshots:
   '@skeletonlabs/skeleton@3.1.4(tailwindcss@4.1.11)':
     dependencies:
       tailwindcss: 4.1.11
-
-  '@standard-schema/spec@1.0.0':
-    optional: true
 
   '@stylistic/eslint-plugin@5.1.0(eslint@9.30.1(jiti@2.4.2))':
     dependencies:
@@ -4188,11 +3990,34 @@ snapshots:
       tailwindcss: 4.1.11
       vite: 6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0)
 
+  '@tanstack/devtools-event-client@0.4.3': {}
+
+  '@tanstack/form-core@1.32.0':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.3
+      '@tanstack/pacer-lite': 0.1.1
+      '@tanstack/store': 0.9.3
+
+  '@tanstack/pacer-lite@0.1.1': {}
+
   '@tanstack/query-core@5.85.5': {}
+
+  '@tanstack/store@0.9.3': {}
+
+  '@tanstack/svelte-form@1.32.0(svelte@5.35.2)':
+    dependencies:
+      '@tanstack/form-core': 1.32.0
+      '@tanstack/svelte-store': 0.10.3(svelte@5.35.2)
+      svelte: 5.35.2
 
   '@tanstack/svelte-query@5.85.5(svelte@5.35.2)':
     dependencies:
       '@tanstack/query-core': 5.85.5
+      svelte: 5.35.2
+
+  '@tanstack/svelte-store@0.10.3(svelte@5.35.2)':
+    dependencies:
+      '@tanstack/store': 0.9.3
       svelte: 5.35.2
 
   '@types/cookie@0.6.0': {}
@@ -4229,26 +4054,9 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/validator@13.15.2':
-    optional: true
-
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.0.13
-
-  '@typeschema/class-validator@0.3.0(@types/json-schema@7.0.15)(class-validator@0.14.2)':
-    dependencies:
-      '@typeschema/core': 0.14.0(@types/json-schema@7.0.15)
-    optionalDependencies:
-      class-validator: 0.14.2
-    transitivePeerDependencies:
-      - '@types/json-schema'
-    optional: true
-
-  '@typeschema/core@0.14.0(@types/json-schema@7.0.15)':
-    optionalDependencies:
-      '@types/json-schema': 7.0.15
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
@@ -4341,21 +4149,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.35.1
       eslint-visitor-keys: 4.2.1
-
-  '@vinejs/compiler@3.0.0':
-    optional: true
-
-  '@vinejs/vine@3.0.1':
-    dependencies:
-      '@poppinss/macroable': 1.0.5
-      '@types/validator': 13.15.2
-      '@vinejs/compiler': 3.0.0
-      camelcase: 8.0.0
-      dayjs: 1.11.13
-      dlv: 1.1.3
-      normalize-url: 8.0.2
-      validator: 13.15.15
-    optional: true
 
   '@vitest/eslint-plugin@1.3.4(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
@@ -4660,12 +4453,6 @@ snapshots:
 
   aria-query@5.3.2: {}
 
-  arktype@2.1.20:
-    dependencies:
-      '@ark/schema': 0.46.0
-      '@ark/util': 0.46.0
-    optional: true
-
   asn1js@3.0.6:
     dependencies:
       pvtsutils: 1.3.6
@@ -4741,9 +4528,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase@8.0.0:
-    optional: true
-
   caniuse-lite@1.0.30001726: {}
 
   ccount@2.0.1: {}
@@ -4764,13 +4548,6 @@ snapshots:
   chownr@3.0.0: {}
 
   ci-info@4.2.0: {}
-
-  class-validator@0.14.2:
-    dependencies:
-      '@types/validator': 13.15.2
-      libphonenumber-js: 1.12.10
-      validator: 13.15.15
-    optional: true
 
   clean-regexp@1.0.0:
     dependencies:
@@ -4839,9 +4616,6 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  dayjs@1.11.13:
-    optional: true
-
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -4868,9 +4642,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dlv@1.1.3:
-    optional: true
-
   drizzle-kit@0.31.4:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
@@ -4891,12 +4662,6 @@ snapshots:
       valibot: 1.1.0(typescript@5.8.3)
 
   earcut@3.0.2: {}
-
-  effect@3.17.7:
-    dependencies:
-      '@standard-schema/spec': 1.0.0
-      fast-check: 3.23.2
-    optional: true
 
   electron-to-chromium@1.5.179: {}
 
@@ -4919,13 +4684,6 @@ snapshots:
       esbuild: 0.25.5
     transitivePeerDependencies:
       - supports-color
-
-  esbuild-runner@2.2.2(esbuild@0.25.5):
-    dependencies:
-      esbuild: 0.25.5
-      source-map-support: 0.5.21
-      tslib: 2.4.0
-    optional: true
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -5308,11 +5066,6 @@ snapshots:
 
   exsolve@1.0.7: {}
 
-  fast-check@3.23.2:
-    dependencies:
-      pure-rand: 6.1.0
-    optional: true
-
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -5458,15 +5211,6 @@ snapshots:
 
   jiti@2.4.2: {}
 
-  joi@17.13.3:
-    dependencies:
-      '@hapi/hoek': 9.3.0
-      '@hapi/topo': 5.1.0
-      '@sideway/address': 4.1.5
-      '@sideway/formula': 3.0.1
-      '@sideway/pinpoint': 2.0.0
-    optional: true
-
   jose@6.0.11: {}
 
   js-base64@3.7.7: {}
@@ -5482,12 +5226,6 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
-
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.28.2
-      ts-algebra: 2.0.0
-    optional: true
 
   json-schema-traverse@0.4.1: {}
 
@@ -5520,9 +5258,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-
-  libphonenumber-js@1.12.10:
-    optional: true
 
   libsql@0.5.13:
     dependencies:
@@ -5787,8 +5522,6 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-
-  memoize-weak@1.0.2: {}
 
   merge2@1.4.1: {}
 
@@ -6058,9 +5791,6 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  normalize-url@8.0.2:
-    optional: true
-
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -6185,15 +5915,9 @@ snapshots:
 
   promise-limit@2.7.0: {}
 
-  property-expr@2.0.6:
-    optional: true
-
   protocol-buffers-schema@3.6.0: {}
 
   punycode@2.3.1: {}
-
-  pure-rand@6.1.0:
-    optional: true
 
   pvtsutils@1.3.6:
     dependencies:
@@ -6388,9 +6112,6 @@ snapshots:
     dependencies:
       kdbush: 4.0.2
 
-  superstruct@2.0.2:
-    optional: true
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -6453,34 +6174,6 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
-  sveltekit-superforms@2.27.1(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.35.2)(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.35.2)(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.5)(svelte@5.35.2)(typescript@5.8.3):
-    dependencies:
-      '@sveltejs/kit': 2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.35.2)(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0)))(svelte@5.35.2)(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0))
-      devalue: 5.1.1
-      memoize-weak: 1.0.2
-      svelte: 5.35.2
-      ts-deepmerge: 7.0.3
-    optionalDependencies:
-      '@exodus/schemasafe': 1.3.0
-      '@gcornut/valibot-json-schema': 0.42.0(esbuild@0.25.5)(typescript@5.8.3)
-      '@sinclair/typebox': 0.34.38
-      '@typeschema/class-validator': 0.3.0(@types/json-schema@7.0.15)(class-validator@0.14.2)
-      '@vinejs/vine': 3.0.1
-      arktype: 2.1.20
-      class-validator: 0.14.2
-      effect: 3.17.7
-      joi: 17.13.3
-      json-schema-to-ts: 3.1.1
-      superstruct: 2.0.2
-      valibot: 1.1.0(typescript@5.8.3)
-      yup: 1.7.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@types/json-schema'
-      - esbuild
-      - typescript
-
   synckit@0.11.8:
     dependencies:
       '@pkgr/core': 0.2.7
@@ -6505,9 +6198,6 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
-  tiny-case@1.0.3:
-    optional: true
-
   tinyexec@1.0.1: {}
 
   tinyglobby@0.2.14:
@@ -6525,15 +6215,9 @@ snapshots:
     dependencies:
       eslint-visitor-keys: 3.4.3
 
-  toposort@2.0.2:
-    optional: true
-
   totalist@3.0.1: {}
 
   tree-kill@1.2.2: {}
-
-  ts-algebra@2.0.0:
-    optional: true
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -6543,11 +6227,6 @@ snapshots:
     dependencies:
       picomatch: 4.0.2
       typescript: 5.8.3
-
-  ts-deepmerge@7.0.3: {}
-
-  tslib@2.4.0:
-    optional: true
 
   tslib@2.8.1: {}
 
@@ -6561,9 +6240,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-fest@2.19.0:
-    optional: true
 
   typescript@5.8.3: {}
 
@@ -6604,17 +6280,9 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valibot@0.42.1(typescript@5.8.3):
-    optionalDependencies:
-      typescript: 5.8.3
-    optional: true
-
   valibot@1.1.0(typescript@5.8.3):
     optionalDependencies:
       typescript: 5.8.3
-
-  validator@13.15.15:
-    optional: true
 
   vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
@@ -6699,20 +6367,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  yup@1.7.0:
-    dependencies:
-      property-expr: 2.0.6
-      tiny-case: 1.0.3
-      toposort: 2.0.2
-      type-fest: 2.19.0
-    optional: true
-
   zimmerframe@1.1.2: {}
-
-  zod-to-json-schema@3.24.6(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-    optional: true
 
   zod@3.25.76: {}
 

--- a/src/lib/components/ConfirmModal.svelte
+++ b/src/lib/components/ConfirmModal.svelte
@@ -30,7 +30,7 @@
     <button
       type="button"
       class="btn preset-outlined-error-500"
-      onclick={onCancel}>Cancelar</button
+      onclick={onCancel}>Cancel</button
     >
 
     <button

--- a/src/lib/components/FormField.svelte
+++ b/src/lib/components/FormField.svelte
@@ -1,22 +1,27 @@
-<script lang="ts">
+<script lang="ts" generics="T">
+  import type { DeepValue } from "@tanstack/svelte-form";
+  import type { FormEventHandler } from "svelte/elements";
+
   type FormFieldProp = {
-    value: string | number | undefined;
+    value: DeepValue<T, string> | string | string[] | number | null | undefined;
     type?: string;
     name?: string;
     label: string;
-    error?: string[];
+    errors: string;
     disabled?: boolean;
     step?: string;
+    oninput: FormEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   };
 
-  let {
+  const {
     label,
-    error,
-    value = $bindable(),
+    errors,
+    value,
     type = "text",
     name,
     disabled = false,
     step,
+    oninput,
   }: FormFieldProp = $props();
 </script>
 
@@ -27,10 +32,11 @@
     <textarea
       {name}
       {disabled}
-      class={["textarea", "resize-none", error && "ring-error-500"]}
+      {oninput}
+      class={["textarea", "resize-none", errors && "ring-error-500"]}
       rows="3"
-      bind:value
-      aria-describedby={error ? `${name}-error` : undefined}
+      value={value as string}
+      aria-describedby={errors ? `${name}-error` : undefined}
     ></textarea>
   {:else}
     <input
@@ -38,14 +44,17 @@
       {disabled}
       {type}
       {step}
-      class={["input", error && "ring-error-500"]}
-      bind:value
-      aria-invalid={error ? "true" : "false"}
-      aria-describedby={error ? `${name}-error` : undefined}
+      {value}
+      {oninput}
+      class={["input", errors && "ring-error-500"]}
+      aria-invalid={errors ? "true" : "false"}
+      aria-describedby={errors ? `${name}-error` : undefined}
     />
   {/if}
 
-  {#if error}
-    <span id={`${name}-error`} class="text-xs text-error-500">{error}</span>
+  {#if errors}
+    <span id={`${name}-error`} class="text-xs text-error-500">
+      {errors}
+    </span>
   {/if}
 </label>

--- a/src/lib/components/LocationFormBase.svelte
+++ b/src/lib/components/LocationFormBase.svelte
@@ -1,0 +1,268 @@
+<script lang="ts" generics="T extends LocationInsertData">
+  import type { LocationInsertData, SearchResult } from "$lib/types";
+  import type { DeepValue, Updater } from "@tanstack/svelte-form";
+  import type { Component, Snippet } from "svelte";
+  import type { GenericSchema } from "valibot";
+  import { beforeNavigate, goto } from "$app/navigation";
+  import { getMapContext } from "$lib/context/map";
+  import { fetchSearchLocations } from "$lib/http/search";
+  import { ArrowLeft, LoaderCircle, MapPin, Plus } from "@lucide/svelte";
+  import { createForm } from "@tanstack/svelte-form";
+  import { HTTPError } from "ky";
+
+  import mapLibre from "maplibre-gl";
+  import ConfirmModal from "./ConfirmModal.svelte";
+
+  type Props = {
+    initialValues: T;
+    schema: GenericSchema<T>;
+    isPending?: boolean;
+    redirectOnConfirm?: string;
+    redirectOnCancel?: string;
+    confirmLabel: string;
+    ConfirmIcon: Component;
+    onsubmit: (value: T) => Promise<void>;
+    onsubmitComplete: () => Promise<void>;
+    fields: Snippet<[any]>;
+  };
+
+  const {
+    initialValues,
+    schema,
+    isPending,
+    redirectOnConfirm = "/dashboard",
+    redirectOnCancel = "/dashboard",
+    confirmLabel,
+    ConfirmIcon,
+    onsubmit,
+    onsubmitComplete,
+    fields,
+  }: Props = $props();
+
+  const mapStore = getMapContext();
+
+  let searchLocations = $state<SearchResult[]>([]);
+  let isSearching = $state(false);
+  let destination = $state(redirectOnConfirm);
+
+  const confirmModal = $state({ open: false });
+  let searchForm: HTMLFormElement;
+
+  const coordinates = $derived.by(() => {
+    const ll = mapLibre.LngLat.convert(mapStore.addMarker);
+
+    return {
+      long: ll.lng,
+      lat: ll.lat,
+    };
+  });
+
+  const form = createForm(() => ({
+    defaultValues: initialValues,
+    validators: {
+      onSubmit: schema,
+      onSubmitAsync: async ({ value }) => {
+        try {
+          await onsubmit(value);
+          form.reset();
+
+          await onsubmitComplete();
+        } catch (err) {
+          if (!(err instanceof HTTPError)) {
+            console.error(err);
+            return;
+          }
+
+          const result: { msg: string } = await err.response.json();
+
+          if (err.response.status === 400) {
+            return {
+              form: "Invalid data",
+              fields: result,
+            };
+          } else {
+            console.error("Unknown error");
+          }
+        }
+      },
+    },
+  }));
+
+  const isDirty = form.useStore((state) => !state.isDefaultValue);
+
+  function handleOnSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    setCoordinates();
+    form.handleSubmit();
+  }
+
+  async function handleSearchLocation(
+    event: SubmitEvent & {
+      currentTarget: HTMLFormElement;
+    },
+  ) {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+    const q = formData.get("q") as string;
+
+    if (!q) {
+      return;
+    }
+
+    try {
+      isSearching = true;
+      const result = await fetchSearchLocations(q);
+      searchLocations = result.locations;
+    } catch (error) {
+      console.error(error);
+    } finally {
+      isSearching = false;
+    }
+  }
+
+  function setLocation(location: SearchResult) {
+    mapStore.showAddMarker = false;
+
+    form.setFieldValue(
+      "name",
+      location.display_name as Updater<DeepValue<T, "name">>,
+    );
+
+    mapStore.addMarker = {
+      lng: Number(location.lon),
+      lat: Number(location.lat),
+    };
+
+    mapStore.showAddMarker = true;
+
+    searchForm.reset();
+  }
+
+  function setCoordinates() {
+    form.setFieldValue("lat", coordinates.lat as Updater<DeepValue<T, "lat">>);
+    form.setFieldValue(
+      "long",
+      coordinates.long as Updater<DeepValue<T, "long">>,
+    );
+  }
+
+  function onModalCancel() {
+    confirmModal.open = false;
+  }
+
+  function onCancel() {
+    goto(redirectOnCancel);
+  }
+
+  function onConfirm() {
+    form.reset(initialValues);
+    goto(destination);
+  }
+
+  beforeNavigate(({ cancel, from, to }) => {
+    const isDiffPage = from?.url.pathname !== to?.url.pathname;
+
+    if (isDirty.current && isDiffPage) {
+      cancel();
+      confirmModal.open = true;
+      if (to?.url.pathname) {
+        destination = to?.url.pathname;
+      }
+    } else {
+      return;
+    }
+    mapStore.resetAddMarker();
+  });
+</script>
+
+<ConfirmModal open={confirmModal.open} {onConfirm} onCancel={onModalCancel} />
+
+<form class="my-5 space-y-6" onsubmit={handleOnSubmit}>
+  {@render fields(form)}
+  <p class="text-xs mb-2">
+    Current coordinates: {coordinates.lat.toFixed(5)}, {coordinates.long.toFixed(
+      5,
+    )}
+  </p>
+
+  <p class="mb-2">To set the coordinates:</p>
+
+  <ul class="list text-sm mb-3">
+    <li class="flex gap-1 items-center">
+      Drag the <MapPin size={18} class="fill-primary-500" /> marker on the map
+    </li>
+    <li>Double click the map</li>
+    <li>Search for a location below</li>
+  </ul>
+
+  <div class="btn-group w-full flex-col p-2 md:flex-row justify-end">
+    <button
+      type="button"
+      class="btn preset-outlined-surface-500"
+      onclick={onCancel}
+    >
+      <ArrowLeft />
+      Cancel
+    </button>
+
+    <button
+      type="submit"
+      disabled={isPending}
+      class="btn preset-filled-primary-500"
+    >
+      {confirmLabel}
+      {#if isPending}
+        <LoaderCircle class="animate-spin" />
+      {:else if ConfirmIcon}
+        <ConfirmIcon />
+      {:else}
+        <Plus />
+      {/if}
+    </button>
+  </div>
+</form>
+
+<form
+  bind:this={searchForm}
+  onsubmit={handleSearchLocation}
+  class="mt-3 flex items-center justify-center"
+  id="nomatin"
+>
+  <input
+    name="q"
+    class="input max-w-[200px]"
+    type="search"
+    placeholder="Input"
+  />
+  <button type="submit" class="btn preset-outlined-surface-500">
+    {#if isSearching}
+      <LoaderCircle class="animate-spin" />
+    {/if}
+    Search
+  </button>
+</form>
+
+<p class="mt-4 text-sm text-right">
+  Search results provider by
+  <a class="anchor" href="https://nominatim.org">nominatin</a>
+</p>
+
+<div class="mt-3 p-1 max-h-60 overflow-auto">
+  {#each searchLocations as location}
+    <div
+      class="flex flex-col gap-2 card mb-2 w-full max-w-md preset-filled-surface-100-900 p-4"
+    >
+      <p class="text-lg text-left">{location.display_name}</p>
+
+      <button
+        onclick={() => setLocation(location)}
+        type="button"
+        class="self-end btn preset-filled-warning-500"
+      >
+        Set location
+        <MapPin />
+      </button>
+    </div>
+  {/each}
+</div>

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -85,7 +85,7 @@
             mapStore.selectedPoint = point;
           }}
           onmouseleave={() => {
-            mapStore.selectedPoint = null;
+            mapStore.selectedPoint = undefined;
           }}
         />
       {/snippet}

--- a/src/lib/server/auth-request-handler.ts
+++ b/src/lib/server/auth-request-handler.ts
@@ -1,8 +1,10 @@
 import type { RequestEvent, RequestHandler } from "@sveltejs/kit";
 import { error } from "@sveltejs/kit";
 
-export function AuthenticatedRequestHandler(handler: RequestHandler) {
-  return async (event: RequestEvent) => {
+export function AuthenticatedRequestHandler<P extends Partial<Record<string, string>>>(
+  handler: RequestHandler<P>,
+) {
+  return async (event: RequestEvent<P>): Promise<Response> => {
     const session = event.locals.session;
 
     if (!session?.user) {

--- a/src/routes/api/locations/[slug]/+server.ts
+++ b/src/routes/api/locations/[slug]/+server.ts
@@ -1,8 +1,9 @@
+import type { RequestHandler } from "./$types";
 import { AuthenticatedRequestHandler } from "$lib/server/auth-request-handler";
 import { findLocation } from "$lib/server/db/queries/location";
 import { json } from "@sveltejs/kit";
 
-export const GET = AuthenticatedRequestHandler(async ({ params, locals }) => {
+export const GET: RequestHandler = AuthenticatedRequestHandler(async ({ params, locals }) => {
   const userId = Number(locals.session?.user.id);
 
   const { slug } = params;

--- a/src/routes/dashboard/add/+page.svelte
+++ b/src/routes/dashboard/add/+page.svelte
@@ -1,53 +1,39 @@
 <script lang="ts">
-  import type { LocationInsertData, SearchResult } from "$lib/types";
-  import type { SuperValidated } from "sveltekit-superforms";
-  import { beforeNavigate, goto } from "$app/navigation";
-
-  import ConfirmModal from "$lib/components/ConfirmModal.svelte";
-
+  import type { LocationInsertData } from "$lib/types";
+  import { goto } from "$app/navigation";
   import FormField from "$lib/components/FormField.svelte";
-
+  import LocationFormBase from "$lib/components/LocationFormBase.svelte";
   import { getMapContext } from "$lib/context/map";
-
   import { fetchCreateLocation } from "$lib/http/location";
-
-  import { fetchSearchLocations } from "$lib/http/search";
-
   import { LocationInsertSchema } from "$lib/schema/location";
-
-  import { ArrowLeft, LoaderCircle, MapPin, Plus } from "@lucide/svelte";
-
+  import { Plus } from "@lucide/svelte";
   import { createMutation } from "@tanstack/svelte-query";
-
-  import { HTTPError } from "ky";
-
   import mapLibre from "maplibre-gl";
-
   import { onMount } from "svelte";
-
-  import {
-    defaults,
-    setError,
-    setMessage,
-    superForm,
-  } from "sveltekit-superforms";
-  import { valibot } from "sveltekit-superforms/adapters";
 
   const mapStore = getMapContext();
 
-  let searchLocations = $state<SearchResult[]>([]);
-  let isSearching = $state(false);
-  let open = $state(false);
-  let destination = "/dashboard";
-  let searchForm: HTMLFormElement;
-
-  const coordinates = $derived.by(() => {
-    const ll = mapLibre.LngLat.convert(mapStore.addMarker);
+  const getCurrentCoordinates = (marker: mapLibre.LngLatLike) => {
+    const ll = mapLibre.LngLat.convert(marker);
 
     return {
       long: ll.lng,
       lat: ll.lat,
     };
+  };
+
+  const coordinates = getCurrentCoordinates(mapStore.addMarker);
+
+  const initialValues = {
+    name: "",
+    description: "",
+    lat: coordinates.lat,
+    long: coordinates.long,
+  } as LocationInsertData;
+
+  const locationMutation = createMutation({
+    mutationKey: ["location"],
+    mutationFn: fetchCreateLocation,
   });
 
   onMount(() => {
@@ -56,135 +42,14 @@
     return () => (mapStore.showAddMarker = false);
   });
 
-  const initialData = {
-    name: "",
-    description: "",
-    lat: 0,
-    long: 0,
-  };
-
-  const locationMutation = createMutation({
-    mutationKey: ["location"],
-    mutationFn: fetchCreateLocation,
-  });
-
-  const { form, errors, enhance, isTainted, reset, message } = superForm(
-    defaults(initialData, valibot(LocationInsertSchema)),
-    {
-      validators: valibot(LocationInsertSchema),
-      SPA: true,
-      resetForm: false,
-      onUpdate: async ({ form }) => {
-        form.data.long = coordinates.long;
-        form.data.lat = coordinates.lat;
-
-        if (form.valid) {
-          const payload = {
-            ...form.data,
-            lat: coordinates.lat,
-            long: coordinates.long,
-          };
-          await addLocation(form, payload);
-        }
-      },
-    },
-  );
-
-  beforeNavigate(({ cancel, from, to }) => {
-    const isDiffPage = from?.url.pathname !== to?.url.pathname;
-
-    if (isTainted() && isDiffPage) {
-      cancel();
-      open = true;
-      destination = to?.url.pathname ?? "/dashboard";
-    } else {
-      mapStore.resetAddMarker();
-    }
-  });
-
-  function onCancel() {
-    goto("/dashboard");
+  async function addLocation(payload: LocationInsertData) {
+    await $locationMutation.mutateAsync(payload);
   }
 
-  function onConfirm() {
-    reset();
-    goto(destination);
-  }
-
-  function onModalCancel() {
-    open = false;
-  }
-
-  async function addLocation(
-    form: SuperValidated<LocationInsertData>,
-    payload: LocationInsertData,
-  ) {
-    try {
-      await $locationMutation.mutateAsync({
-        ...payload,
-      });
-      reset();
-
-      return goto("/dashboard", {
-        invalidateAll: true,
-      });
-    } catch (err: unknown) {
-      const error = err as HTTPError;
-
-      const result: { msg: string } = await error.response.json();
-
-      if (error.response.status === 400) {
-        for (const [key, value] of Object.entries(result)) {
-          setError(form, key as keyof typeof $form, value as string);
-        }
-      } else {
-        setMessage(form, result.msg);
-      }
-    }
-  }
-
-  async function searchLocation(
-    event: SubmitEvent & {
-      currentTarget: HTMLFormElement;
-    },
-  ) {
-    event.preventDefault();
-
-    const formData = new FormData(event.currentTarget);
-    const q = formData.get("q") as string;
-
-    if (!q) {
-      return;
-    }
-
-    try {
-      isSearching = true;
-      const result = await fetchSearchLocations(q);
-      searchLocations = result.locations;
-    } catch (error) {
-      console.error(error);
-    } finally {
-      isSearching = false;
-    }
-  }
-
-  function setLocation(location: SearchResult) {
-    mapStore.showAddMarker = false;
-
-    $form.name = location.display_name;
-
-    mapStore.addMarker = {
-      lng: Number(location.lon),
-      lat: Number(location.lat),
-    };
-
-    mapStore.showAddMarker = true;
-
-    searchForm.reset();
+  async function redirectToDashboard() {
+    await goto("/dashboard", { invalidateAll: true });
   }
 </script>
-
-<ConfirmModal {open} {onConfirm} onCancel={onModalCancel} />
 
 <div class="py-6 px-2">
   <h1 class="h5">Add Location</h1>
@@ -195,104 +60,52 @@
     this location after adding it.
   </p>
 
-  <form class="my-5 space-y-6" use:enhance>
-    {#if !!$message}
-      <p class="text-error-500">{$message}</p>
-    {/if}
-
-    <FormField label="Name" bind:value={$form.name} error={$errors.name} />
-
-    <FormField
-      label="Description"
-      type="textarea"
-      bind:value={$form.description}
-      error={$errors.description}
-      disabled={$locationMutation.isPending}
-    />
-
-    <p class="text-xs mb-2">
-      Current coordinates: {coordinates.long.toFixed(5)}, {coordinates.lat.toFixed(
-        5,
-      )}
-    </p>
-
-    <p class="mb-2">To set the coordinates:</p>
-
-    <ul class="list text-sm mb-3">
-      <li class="flex gap-1 items-center">
-        Drag the <MapPin size={18} class="fill-primary-500" /> marker on the map
-      </li>
-      <li>Double click the map</li>
-      <li>Search for a location below</li>
-    </ul>
-
-    <div class="btn-group w-full flex-col p-2 md:flex-row justify-end">
-      <button
-        type="button"
-        class="btn preset-outlined-surface-500"
-        onclick={onCancel}
-      >
-        <ArrowLeft />
-        Cancel
-      </button>
-
-      <button
-        type="submit"
-        disabled={$locationMutation.isPending}
-        class="btn preset-filled-primary-500"
-      >
-        Add
-        {#if $locationMutation.isPending}
-          <LoaderCircle class="animate-spin" />
-        {:else}
-          <Plus />
-        {/if}
-      </button>
-    </div>
-  </form>
-  <hr class="hr" />
-
-  <p class="mt-4 text-sm text-right">
-    Search results provider by
-    <a class="anchor" href="https://nominatim.org">nominatin</a>
-  </p>
-
-  <form
-    bind:this={searchForm}
-    onsubmit={searchLocation}
-    class="mt-3 flex items-center justify-center"
-    id="nomatin"
+  <LocationFormBase
+    {initialValues}
+    schema={LocationInsertSchema}
+    redirectOnCancel="/dashboard"
+    redirectOnConfirm="/dashboard"
+    confirmLabel="Add"
+    ConfirmIcon={Plus}
+    isPending={$locationMutation.isPending}
+    onsubmit={addLocation}
+    onsubmitComplete={redirectToDashboard}
   >
-    <input
-      name="q"
-      class="input max-w-[200px]"
-      type="search"
-      placeholder="Input"
-    />
-    <button type="submit" class="btn preset-outlined-surface-500">
-      {#if isSearching}
-        <LoaderCircle class="animate-spin" />
-      {/if}
-      Search
-    </button>
-  </form>
+    {#snippet fields(form)}
+      <form.Field name="name">
+        {#snippet children(field: any)}
+          <FormField
+            label="Name"
+            name="name"
+            value={field.state.value}
+            errors={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+            oninput={(e) => {
+              const target = e.target as HTMLInputElement;
+              field.handleChange(target.value);
+            }}
+          />
+        {/snippet}
+      </form.Field>
 
-  <div class="mt-3 p-1 max-h-60 overflow-auto">
-    {#each searchLocations as location}
-      <div
-        class="flex flex-col gap-2 card mb-2 w-full max-w-md preset-filled-surface-100-900 p-4"
-      >
-        <p class="text-lg text-left">{location.display_name}</p>
-
-        <button
-          onclick={() => setLocation(location)}
-          type="button"
-          class="self-end btn preset-filled-warning-500"
-        >
-          Set location
-          <MapPin />
-        </button>
-      </div>
-    {/each}
-  </div>
+      <form.Field name="description">
+        {#snippet children(field: any)}
+          <FormField
+            label="Description"
+            type="textarea"
+            name="description"
+            value={field.state.value}
+            errors={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+            oninput={(e) => {
+              const target = e.target as HTMLTextAreaElement;
+              field.handleChange(target.value);
+            }}
+          />
+        {/snippet}
+      </form.Field>
+    {/snippet}
+  </LocationFormBase>
 </div>

--- a/src/routes/dashboard/location/[slug]/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
+  import { goto } from "$app/navigation";
   import {
     EllipsisVertical,
     MapPinPlus,
@@ -12,6 +13,10 @@
 
   let open = $state(false);
   let buttonEl = $state<HTMLButtonElement>();
+
+  function gotoLocationEdit() {
+    goto(`/dashboard/location/${data.location.slug}/edit`);
+  }
 </script>
 
 <div class="flex gap-2 items-center">
@@ -46,7 +51,11 @@
         class="rounded-button data-highlighted:bg-muted ring-0! ring-transparent! flex h-10 select-none items-center py-1 pl-2 pr-1.5 text-sm font-medium focus-visible:outline-none"
       >
         <div class="w-full">
-          <button type="button" class="w-full btn preset-tonal-surface">
+          <button
+            onclick={gotoLocationEdit}
+            type="button"
+            class="w-full btn preset-tonal-surface"
+          >
             <PenLine size={16} />
             Edit
           </button>

--- a/src/routes/dashboard/location/[slug]/edit/+page.server.ts
+++ b/src/routes/dashboard/location/[slug]/edit/+page.server.ts
@@ -1,0 +1,21 @@
+import type { Location } from "$lib/types";
+import type { PageServerLoad } from "./$types";
+import { error } from "@sveltejs/kit";
+
+export const load: PageServerLoad = async ({ fetch, params }) => {
+  const slug = params.slug;
+
+  const response = await fetch(`/api/locations/${slug}`);
+
+  if (!response.ok) {
+    const body = await response.json();
+    error(response.status, body);
+  }
+
+  const data = await response.json();
+  const location = data.location as Location;
+
+  return {
+    location,
+  };
+};

--- a/src/routes/dashboard/location/[slug]/edit/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/edit/+page.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+</script>
+
+<h1>Location Edit Page</h1>


### PR DESCRIPTION
## Summary

- Replaces `sveltekit-superforms` with `@tanstack/svelte-form`
- Extracts shared form logic (validation, Nominatim search, unsaved-changes guard) into a reusable `LocationFormBase` component to support both add and edit flows
- Adds location edit page stub with server-side data loading
- Makes `AuthenticatedRequestHandler` generic over route params for proper TypeScript inference

## Fixes

- Guard `instanceof HTTPError` before accessing `.response` in `LocationFormBase` catch block
- `await goto` in `redirectToDashboard` to surface navigation errors
- `invalidateAll: true` on dashboard redirect to avoid stale location list
- Remove unnecessary spread in `mutateAsync` call
- Fix mixed-language label in `ConfirmModal` (`Cancelar` → `Cancel`)

## Test plan

- [x] Add a location via `/dashboard/add` — form validates, marker coordinates are submitted, redirects to dashboard with updated list
- [x] Move the marker before submitting — coordinates update correctly
- [x] Search a location via Nominatim — marker and name field update
- [x] Fill the form and navigate away via nav links — unsaved-changes modal appears, cancel keeps you on the page, confirm navigates away
- [x] Fill the form and click Cancel — modal appears, confirm navigates to `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)