### PR TITLE
feat: add location edit page and PUT API

### DIFF
--- a/src/lib/components/LocationFormBase.svelte
+++ b/src/lib/components/LocationFormBase.svelte
@@ -75,13 +75,17 @@
 
           const result: { msg: string } = await err.response.json();
 
-          if (err.response.status === 400) {
-            return {
-              form: "Invalid data",
-              fields: result,
-            };
-          } else {
-            console.error("Unknown error");
+          switch (err.response.status) {
+            case 400:
+              return {
+                form: "Invalid data",
+                fields: result,
+              };
+            case 404:
+            case 409:
+              return result.msg;
+            default:
+              return "Unknown error";
           }
         }
       },
@@ -89,6 +93,7 @@
   }));
 
   const isDirty = form.useStore((state) => !state.isDefaultValue);
+  const error = form.useStore((state) => state.errorMap.onSubmit);
 
   function handleOnSubmit(e: SubmitEvent) {
     e.preventDefault();
@@ -169,16 +174,21 @@
       if (to?.url.pathname) {
         destination = to?.url.pathname;
       }
-    } else {
       return;
     }
-    mapStore.resetAddMarker();
+    if (isDiffPage) {
+      mapStore.resetAddMarker();
+    }
   });
 </script>
 
 <ConfirmModal open={confirmModal.open} {onConfirm} onCancel={onModalCancel} />
 
 <form class="my-5 space-y-6" onsubmit={handleOnSubmit}>
+  {#if error.current && typeof error.current === "string"}
+    <p class="text-error-500">{error.current}</p>
+  {/if}
+
   {@render fields(form)}
   <p class="text-xs mb-2">
     Current coordinates: {coordinates.lat.toFixed(5)}, {coordinates.long.toFixed(
@@ -190,7 +200,7 @@
 
   <ul class="list text-sm mb-3">
     <li class="flex gap-1 items-center">
-      Drag the <MapPin size={18} class="fill-primary-500" /> marker on the map
+      Drag the <MapPin size={18} class="fill-warning-500" /> marker on the map
     </li>
     <li>Double click the map</li>
     <li>Search for a location below</li>
@@ -227,7 +237,7 @@
   bind:this={searchForm}
   onsubmit={handleSearchLocation}
   class="mt-3 flex items-center justify-center"
-  id="nomatin"
+  id="nominatim"
 >
   <input
     name="q"
@@ -244,8 +254,8 @@
 </form>
 
 <p class="mt-4 text-sm text-right">
-  Search results provider by
-  <a class="anchor" href="https://nominatim.org">nominatin</a>
+  Search results provided by
+  <a class="anchor" href="https://nominatim.org">nominatim</a>
 </p>
 
 <div class="mt-3 p-1 max-h-60 overflow-auto">

--- a/src/lib/components/LocationNavItems.svelte
+++ b/src/lib/components/LocationNavItems.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import type { Location } from "$lib/types";
   import NavItem from "$lib/components/NavItem.svelte";
-  import { getMapContext } from "$lib/context/map";
-  import { createMapPointFromLocation } from "$lib/utils/map";
 
   import { ArrowLeft, Map } from "@lucide/svelte";
 
@@ -11,16 +9,6 @@
   };
 
   const { location }: Props = $props();
-  const mapStore = getMapContext();
-
-  if (location) {
-    const mapPoint = createMapPointFromLocation(
-      location,
-      `/dashboard/location/${location.slug}`,
-    );
-
-    mapStore.mapPoints = () => [mapPoint];
-  }
 </script>
 
 <NavItem href="/dashboard" label="Back to locations">

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -65,7 +65,7 @@
   {#if mapStore.showAddMarker}
     <Marker bind:lnglat={mapStore.addMarker} draggable>
       {#snippet content()}
-        <MapPin class="fill-primary-500" size={32} />
+        <MapPin class="fill-warning-500" size={32} />
       {/snippet}
 
       <Popup class="text-black" open closeButton={false}>

--- a/src/lib/http/location.ts
+++ b/src/lib/http/location.ts
@@ -5,3 +5,7 @@ import ky from "ky";
 export async function fetchCreateLocation(location: LocationInsertData) {
   return await ky.post("/api/locations", { json: location }).json();
 }
+
+export async function fetchUpdateLocation({ slug, location }: { slug: string; location: LocationInsertData }) {
+  return await ky.put(`/api/locations/${slug}`, { json: location }).json();
+}

--- a/src/lib/server/db/queries/location.ts
+++ b/src/lib/server/db/queries/location.ts
@@ -29,3 +29,18 @@ export async function findLocation(userId: number, slug: string) {
     ),
   });
 }
+
+export async function updateLocation(userId: number, slug: string, data: LocationInsertData) {
+  const [updatedLocation] = await db.update(location)
+    .set(data)
+    .where(
+      and(
+        eq(location.userId, userId),
+        eq(location.slug, slug),
+      ),
+
+    )
+    .returning();
+
+  return updatedLocation;
+}

--- a/src/lib/server/services/insert-location.ts
+++ b/src/lib/server/services/insert-location.ts
@@ -4,23 +4,13 @@ import type { Location, LocationInsertData } from "$lib/types";
 import type { DrizzleQueryError } from "drizzle-orm/errors";
 
 import { insertLocation } from "$lib/server/db/queries/location";
-
 import { InternalServerError, UniqueConstraint } from "$lib/server/errors";
+
 import { generateUniqueSlug } from "$lib/server/utils/slug";
-
 import slugify from "slug";
+import { isNameConstraintError, isSlugConstraintError } from "../utils/constraints";
 
-const NAME_CONSTRAINT_MESSAGE = "SQLITE_CONSTRAINT: SQLite error: UNIQUE constraint failed: location.name, location.user_id";
-const SLUG_CONSTRAINT_MESSAGE = "SQLITE_CONSTRAINT: SQLite error: UNIQUE constraint failed: location.slug";
 const MAX_ATTEMPTS = 3;
-
-function isNameConstraintError(error: DrizzleQueryError) {
-  return error.cause?.message === NAME_CONSTRAINT_MESSAGE;
-}
-
-function isSlugConstraintError(error: DrizzleQueryError) {
-  return error.cause?.message === SLUG_CONSTRAINT_MESSAGE;
-}
 
 export class InsertLocation {
   static async execute(data: LocationInsertData, userId: number): Promise<Response<Location, Error>> {
@@ -47,6 +37,6 @@ export class InsertLocation {
         }
       }
     }
-    return { success: false, value: new InternalServerError("Internal server error: \"Failed to create location. Please try again") };
+    return { success: false, value: new InternalServerError("Failed to create location. Please try again.") };
   }
 }

--- a/src/lib/server/utils/constraints.ts
+++ b/src/lib/server/utils/constraints.ts
@@ -1,0 +1,9 @@
+import type { DrizzleQueryError } from "drizzle-orm/errors";
+
+export function isNameConstraintError(error: DrizzleQueryError) {
+  return error.cause?.message?.includes("UNIQUE constraint failed: location.name") ?? false;
+}
+
+export function isSlugConstraintError(error: DrizzleQueryError) {
+  return error.cause?.message?.includes("UNIQUE constraint failed: location.slug") ?? false;
+}

--- a/src/lib/stores/map.svelte.ts
+++ b/src/lib/stores/map.svelte.ts
@@ -1,4 +1,4 @@
-import type { MapPoint, SidebarItem } from "$lib/types";
+import type { MapPoint } from "$lib/types";
 import type { LngLatLike, Map } from "maplibre-gl";
 
 import { CENTER_BRASIL } from "$lib/constants";
@@ -16,13 +16,10 @@ type MapStore = {
   resetAddMarker: () => void;
 };
 
-export function createMapStore(store: () => SidebarItem[]) {
-  const mapPoints = $derived.by(() => {
-    return store().map(item => item.mapPoint);
-  });
+export function createMapStore(store: () => MapPoint[]) {
   const mapStore = $state<MapStore>({
     map: undefined,
-    mapPoints: () => mapPoints,
+    mapPoints: () => store(),
     selectedPoint: undefined,
     addMarker: CENTER_BRASIL as LngLatLike,
     showAddMarker: false,
@@ -50,7 +47,8 @@ export function createMapStore(store: () => SidebarItem[]) {
     flyToAddMarker: () => {
       mapStore.map?.flyTo({
         center: mapStore.addMarker,
-        zoom: 6,
+        zoom: 12,
+        minZoom: 3,
       });
     },
     resetAddMarker: () => {

--- a/src/routes/api/locations/[slug]/+server.ts
+++ b/src/routes/api/locations/[slug]/+server.ts
@@ -1,22 +1,76 @@
+import type { DrizzleQueryError } from "drizzle-orm/errors";
 import type { RequestHandler } from "./$types";
+import { LocationInsertSchema } from "$lib/schema";
 import { AuthenticatedRequestHandler } from "$lib/server/auth-request-handler";
-import { findLocation } from "$lib/server/db/queries/location";
+import { findLocation, updateLocation } from "$lib/server/db/queries/location";
+import { isNameConstraintError } from "$lib/server/utils/constraints";
+import { formatValibotIssues } from "$lib/utils/valibot-format-error";
 import { json } from "@sveltejs/kit";
+import * as v from "valibot";
 
 export const GET: RequestHandler = AuthenticatedRequestHandler(async ({ params, locals }) => {
   const userId = Number(locals.session?.user.id);
 
   const { slug } = params;
 
-  const location = await findLocation(userId, slug);
+  try {
+    const location = await findLocation(userId, slug);
 
-  if (!location) {
+    if (!location) {
+      return json({
+        msg: "Location not found",
+      }, {
+        status: 404,
+      });
+    }
+
+    return json({ location });
+  } catch {
     return json({
-      msg: "slug not found",
+      msg: "Internal server error",
     }, {
-      status: 404,
+      status: 500,
+    });
+  }
+});
+
+export const PUT: RequestHandler = AuthenticatedRequestHandler(async ({ params, locals, request }) => {
+  const userId = Number(locals.session?.user.id);
+
+  const body = await request.json();
+  const { slug } = params;
+
+  const result = v.safeParse(LocationInsertSchema, body);
+
+  if (!result.success) {
+    return json(formatValibotIssues(result.issues), {
+      status: 400,
     });
   }
 
-  return json({ location });
+  const validatedData = result.output;
+
+  try {
+    const location = await updateLocation(userId, slug, validatedData);
+
+    if (!location) {
+      return json({
+        msg: "Location not found",
+      }, {
+        status: 404,
+      });
+    }
+
+    return json({ location });
+  } catch (err) {
+    const error = err as DrizzleQueryError;
+
+    if (isNameConstraintError(error)) {
+      return json({ msg: "A location with this name already exists." }, { status: 409 });
+    }
+
+    return json({
+      msg: "Internal server error",
+    }, { status: 500 });
+  }
 });

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Location, SidebarItem } from "$lib/types";
+  import type { Location, MapPoint, SidebarItem } from "$lib/types";
   import type { LayoutProps } from "./$types";
 
   import { page } from "$app/state";
@@ -41,24 +41,31 @@
   }
 
   const sidebarItems = $derived.by<SidebarItem[]>(() => {
-    if (page.route.id === "/dashboard") {
-      return (
-        locations?.map((location) => {
-          return {
-            id: `location-${location.id}`,
-            mapPoint: createMapPointFromLocation(
-              location,
-              `/dashboard/location/${location.slug}`,
-            ),
-          };
-        }) ?? []
-      );
+    if (navGroup !== "dashboard" || !locations) {
+      return [];
     }
 
+    return locations.map((l) => ({
+      id: `item-${l.slug}`,
+      mapPoint: createMapPointFromLocation(l, `/dashboard/location/${l.slug}`),
+    }));
+  });
+
+  const mapPoints = $derived.by<MapPoint[]>(() => {
+    if (navGroup === "dashboard")
+      return sidebarItems.map((item) => item.mapPoint);
+    if (navGroup === "location" && location) {
+      return [
+        createMapPointFromLocation(
+          location,
+          `/dashboard/location/${location.slug}`,
+        ),
+      ];
+    }
     return [];
   });
 
-  const mapStore = createMapStore(() => sidebarItems);
+  const mapStore = createMapStore(() => mapPoints);
   setMapContext(mapStore);
 </script>
 

--- a/src/routes/dashboard/location/[slug]/edit/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/edit/+page.svelte
@@ -1,4 +1,99 @@
 <script lang="ts">
+  import type { LocationInsertData } from "$lib/types";
+  import type { PageProps } from "./$types";
+  import { goto } from "$app/navigation";
+  import FormField from "$lib/components/FormField.svelte";
+  import LocationFormBase from "$lib/components/LocationFormBase.svelte";
+  import { getMapContext } from "$lib/context/map";
+  import { fetchUpdateLocation } from "$lib/http/location";
+  import { LocationInsertSchema } from "$lib/schema/location";
+  import { MapPinIcon } from "@lucide/svelte";
+  import { createMutation } from "@tanstack/svelte-query";
+  import { onMount } from "svelte";
+
+  const { data }: PageProps = $props();
+  const mapStore = getMapContext();
+
+  const initialValues = {
+    name: data.location.name,
+    description: data.location.description,
+    lat: data.location.lat,
+    long: data.location.long,
+  } as LocationInsertData;
+
+  const updatedMutation = createMutation({
+    mutationKey: ["location"],
+    mutationFn: fetchUpdateLocation,
+  });
+
+  onMount(() => {
+    mapStore.addMarker = { lat: data.location.lat, lng: data.location.long };
+    mapStore.showAddMarker = true;
+
+    return () => (mapStore.showAddMarker = false);
+  });
+
+  async function handleUpdate(payload: LocationInsertData) {
+    await $updatedMutation.mutateAsync({
+      location: payload,
+      slug: data.location.slug,
+    });
+  }
+
+  async function redirectToDashboard() {
+    await goto(`/dashboard/location/${data.location.slug}`, {
+      invalidateAll: true,
+    });
+  }
 </script>
 
-<h1>Location Edit Page</h1>
+<div class="py-6 px-2">
+  <LocationFormBase
+    {initialValues}
+    schema={LocationInsertSchema}
+    redirectOnCancel={`/dashboard/location/${data.location.slug}`}
+    redirectOnConfirm={`/dashboard/location/${data.location.slug}`}
+    confirmLabel="Update"
+    ConfirmIcon={MapPinIcon}
+    isPending={$updatedMutation.isPending}
+    onsubmit={handleUpdate}
+    onsubmitComplete={redirectToDashboard}
+  >
+    {#snippet fields(form)}
+      <form.Field name="name">
+        {#snippet children(field: any)}
+          <FormField
+            label="Name"
+            name="name"
+            value={field.state.value}
+            errors={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+            oninput={(e) => {
+              const target = e.target as HTMLInputElement;
+              field.handleChange(target.value);
+            }}
+          />
+        {/snippet}
+      </form.Field>
+
+      <form.Field name="description">
+        {#snippet children(field: any)}
+          <FormField
+            label="Description"
+            type="textarea"
+            name="description"
+            value={field.state.value}
+            errors={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+            oninput={(e) => {
+              const target = e.target as HTMLTextAreaElement;
+              field.handleChange(target.value);
+            }}
+          />
+        {/snippet}
+      </form.Field>
+    {/snippet}
+  </LocationFormBase>
+</div>


### PR DESCRIPTION
## Summary


Fix: #34
 
- Add `PUT /api/locations/[slug]` handler with valibot validation and name constraint detection
- Implement location edit page (`/dashboard/location/[slug]/edit`) reusing `LocationFormBase` with map marker pre-populated from existing coordinates
- Add `updateLocation` and `findLocation` DB queries; add `fetchUpdateLocation` HTTP client
- Extract constraint detection (`isNameConstraintError`, `isSlugConstraintError`) into shared `src/lib/server/utils/constraints.ts` using `includes()` instead of fragile exact string match
- Remove hardcoded SQLite constraint message constants from `constants.ts`
- Fix `beforeNavigate` in `LocationFormBase`: marker is now only reset on actual navigation away, not when the dirty-form modal opens
- Refactor `createMapStore` to accept `() => MapPoint[]` directly; derive map points per `navGroup` in dashboard layout so location detail pages show the correct single pin
- Standardize 404 response messages; remove dead `isSlugConstraintError` branch from PUT handler
- Fix typos: `nominatim` id/text, "provided by"; normalize `lon` → `lng` in `addMarker`

## Test plan

- [ ] Navigate to an existing location and open the edit page — marker should appear at the correct coordinates
- [ ] Edit name/description and submit — confirm redirect to detail page with updated data
- [ ] Try to duplicate an existing location name — confirm 409 error message is shown in the form
- [ ] Dirty form + click away → confirm modal appears and marker is **not** reset; cancel modal and marker is still in place
- [ ] Dirty form + click same-page link → confirm marker is **not** reset
- [ ] Clean form navigation → confirm marker is reset correctly
- [ ] Dashboard map shows all location pins; location detail page shows only the single pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)