### PR TITLE
feat: add delete location with confirmation modal and shared ky client

### DIFF
--- a/src/lib/components/DeleteLocationModal.svelte
+++ b/src/lib/components/DeleteLocationModal.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  type ConfirmModalProps = {
+    open?: boolean;
+    onConfirm?: () => void;
+    onCancel?: () => void;
+  };
+
+  const { open = false, onConfirm, onCancel }: ConfirmModalProps = $props();
+
+  let dialog: HTMLDialogElement;
+
+  $effect(() => {
+    open ? dialog.showModal() : dialog.close();
+  });
+
+  function confirm() {
+    onConfirm?.();
+  }
+</script>
+
+<dialog
+  bind:this={dialog}
+  class="rounded-container bg-surface-100-900 text-inherit max-w-[640px] top-1/2 left-1/2 -translate-1/2 p-4 space-y-4 z-10 backdrop:bg-surface-50/75 dark:backdrop:bg-surface-950/75"
+>
+  <h2 class="h4">Delete Location</h2>
+  <p>Are you sure you want to delete location?</p>
+  <form method="dialog" class="btn-group flex justify-end">
+    <button
+      type="button"
+      class="btn preset-outlined-error-500"
+      onclick={onCancel}>Cancel</button
+    >
+
+    <button
+      type="button"
+      class="btn preset-filled-primary-500"
+      onclick={confirm}>Confirm</button
+    >
+  </form>
+</dialog>
+
+<style>
+  dialog,
+  dialog::backdrop {
+    --anim-duration: 250ms;
+    transition:
+      display var(--anim-duration) allow-discrete,
+      overlay var(--anim-duration) allow-discrete,
+      opacity var(--anim-duration);
+    opacity: 0;
+  }
+  dialog[open],
+  dialog[open]::backdrop {
+    opacity: 1;
+  }
+  @starting-style {
+    dialog[open],
+    dialog[open]::backdrop {
+      opacity: 0;
+    }
+  }
+</style>

--- a/src/lib/components/DeleteLocationModal.svelte
+++ b/src/lib/components/DeleteLocationModal.svelte
@@ -1,21 +1,23 @@
 <script lang="ts">
+  import { LoaderCircle } from "@lucide/svelte";
+
   type ConfirmModalProps = {
     open?: boolean;
+    isPending?: boolean;
+    name?: string;
     onConfirm?: () => void;
     onCancel?: () => void;
   };
 
-  const { open = false, onConfirm, onCancel }: ConfirmModalProps = $props();
+  const { open = false, isPending = false, name, onConfirm, onCancel }: ConfirmModalProps = $props();
 
   let dialog: HTMLDialogElement;
 
   $effect(() => {
+    if (!dialog)
+      return;
     open ? dialog.showModal() : dialog.close();
   });
-
-  function confirm() {
-    onConfirm?.();
-  }
 </script>
 
 <dialog
@@ -23,7 +25,7 @@
   class="rounded-container bg-surface-100-900 text-inherit max-w-[640px] top-1/2 left-1/2 -translate-1/2 p-4 space-y-4 z-10 backdrop:bg-surface-50/75 dark:backdrop:bg-surface-950/75"
 >
   <h2 class="h4">Delete Location</h2>
-  <p>Are you sure you want to delete location?</p>
+  <p>Are you sure you want to delete <strong>{name}</strong>?</p>
   <form method="dialog" class="btn-group flex justify-end">
     <button
       type="button"
@@ -34,8 +36,14 @@
     <button
       type="button"
       class="btn preset-filled-primary-500"
-      onclick={confirm}>Confirm</button
+      disabled={isPending}
+      onclick={onConfirm}
     >
+      {#if isPending}
+        <LoaderCircle class="animate-spin" size={16} />
+      {/if}
+      Confirm
+    </button>
   </form>
 </dialog>
 

--- a/src/lib/http/client.ts
+++ b/src/lib/http/client.ts
@@ -1,0 +1,5 @@
+import ky from "ky";
+
+export const api = ky.create({
+  retry: 0,
+});

--- a/src/lib/http/location.ts
+++ b/src/lib/http/location.ts
@@ -1,11 +1,14 @@
 import type { LocationInsertData } from "$lib/types";
-
-import ky from "ky";
+import { api } from "$lib/http/client";
 
 export async function fetchCreateLocation(location: LocationInsertData) {
-  return await ky.post("/api/locations", { json: location }).json();
+  return await api.post("/api/locations", { json: location }).json();
 }
 
 export async function fetchUpdateLocation({ slug, location }: { slug: string; location: LocationInsertData }) {
-  return await ky.put(`/api/locations/${slug}`, { json: location }).json();
+  return await api.put(`/api/locations/${slug}`, { json: location }).json();
+}
+
+export async function fetchDeleteLocation(slug: string) {
+  await api.delete(`/api/locations/${slug}`);
 }

--- a/src/lib/http/search.ts
+++ b/src/lib/http/search.ts
@@ -1,11 +1,11 @@
 import type { SearchResult } from "$lib/types";
-import ky from "ky";
+import { api } from "$lib/http/client";
 
 interface Response {
   locations: SearchResult[];
 }
 export async function fetchSearchLocations(search: string): Promise<Response> {
-  return await ky.get("/api/search?q", {
+  return await api.get("/api/search", {
     searchParams: {
       q: search,
     },

--- a/src/lib/server/db/queries/location.ts
+++ b/src/lib/server/db/queries/location.ts
@@ -44,3 +44,14 @@ export async function updateLocation(userId: number, slug: string, data: Locatio
 
   return updatedLocation;
 }
+
+export async function deleteLocation(userId: number, slug: string) {
+  const [deletedLocation] = await db.delete(location)
+    .where(and(
+      eq(location.userId, userId),
+      eq(location.slug, slug),
+    ))
+    .returning();
+
+  return deletedLocation;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,6 +17,10 @@
     defaultOptions: {
       queries: {
         enabled: browser,
+        retry: false,
+      },
+      mutations: {
+        retry: false,
       },
     },
   });

--- a/src/routes/api/locations/[slug]/+server.ts
+++ b/src/routes/api/locations/[slug]/+server.ts
@@ -2,7 +2,7 @@ import type { DrizzleQueryError } from "drizzle-orm/errors";
 import type { RequestHandler } from "./$types";
 import { LocationInsertSchema } from "$lib/schema";
 import { AuthenticatedRequestHandler } from "$lib/server/auth-request-handler";
-import { findLocation, updateLocation } from "$lib/server/db/queries/location";
+import { deleteLocation, findLocation, updateLocation } from "$lib/server/db/queries/location";
 import { isNameConstraintError } from "$lib/server/utils/constraints";
 import { formatValibotIssues } from "$lib/utils/valibot-format-error";
 import { json } from "@sveltejs/kit";
@@ -70,6 +70,28 @@ export const PUT: RequestHandler = AuthenticatedRequestHandler(async ({ params, 
     }
 
     return json({
+      msg: "Internal server error",
+    }, { status: 500 });
+  }
+});
+
+export const DELETE: RequestHandler = AuthenticatedRequestHandler(async ({ params, locals }) => {
+  const userId = Number(locals.session?.user.id);
+  const { slug } = params;
+
+  try {
+    const location = await deleteLocation(userId, slug);
+
+    if (!location) {
+      return json({
+        msg: "Location not found",
+      }, { status: 404 });
+    }
+
+    return new Response(null, { status: 204 });
+  } catch {
+    return json({
+
       msg: "Internal server error",
     }, { status: 500 });
   }

--- a/src/routes/dashboard/location/[slug]/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/+page.svelte
@@ -6,7 +6,6 @@
 
   import {
     EllipsisVertical,
-    LoaderCircle,
     MapPinPlus,
     PenLine,
     Trash2,
@@ -58,6 +57,8 @@
 
 <DeleteLocationModal
   open={openDeleteModal}
+  isPending={$deleteMutation.isPending}
+  name={data.location.name}
   onCancel={() => (openDeleteModal = false)}
   onConfirm={deleteLocation}
 />
@@ -89,11 +90,7 @@
             type="button"
             class="w-full btn preset-tonal-surface"
           >
-            {#if $deleteMutation.isPending}
-              <LoaderCircle class="animate-spin" />
-            {:else}
-              <Trash2 size={16} />
-            {/if}
+            <Trash2 size={16} />
             Delete
           </button>
         </div>

--- a/src/routes/dashboard/location/[slug]/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/+page.svelte
@@ -1,23 +1,66 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
   import { goto } from "$app/navigation";
+  import DeleteLocationModal from "$lib/components/DeleteLocationModal.svelte";
+  import { fetchDeleteLocation } from "$lib/http/location";
+
   import {
     EllipsisVertical,
+    LoaderCircle,
     MapPinPlus,
     PenLine,
     Trash2,
   } from "@lucide/svelte";
+  import { createMutation } from "@tanstack/svelte-query";
   import { DropdownMenu } from "bits-ui";
+  import { HTTPError } from "ky";
 
   const { data }: PageProps = $props();
 
   let open = $state(false);
+  let openDeleteModal = $state(false);
   let buttonEl = $state<HTMLButtonElement>();
+
+  const deleteMutation = createMutation({
+    mutationKey: ["location"],
+    mutationFn: async (slug: string) => {
+      try {
+        const data = await fetchDeleteLocation(slug);
+
+        return data;
+      } catch (error) {
+        if (error instanceof HTTPError && error.response.status === 404) {
+          const result = (await error.response.json()) as { msg: string };
+          throw new Error(result.msg);
+        }
+
+        throw new Error("Unknown error");
+      }
+    },
+  });
 
   function gotoLocationEdit() {
     goto(`/dashboard/location/${data.location.slug}/edit`);
   }
+
+  async function deleteLocation() {
+    try {
+      await $deleteMutation.mutateAsync(data.location.slug);
+
+      goto("/dashboard", {
+        invalidateAll: true,
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  }
 </script>
+
+<DeleteLocationModal
+  open={openDeleteModal}
+  onCancel={() => (openDeleteModal = false)}
+  onConfirm={deleteLocation}
+/>
 
 <div class="flex gap-2 items-center">
   <h1 class="h5 truncate">{data.location.name}</h1>
@@ -41,8 +84,16 @@
         class="rounded-button data-highlighted:bg-muted ring-0! ring-transparent! flex h-10 select-none items-center py-1 pl-2 pr-1.5 text-sm font-medium focus-visible:outline-none"
       >
         <div class="w-full">
-          <button type="button" class="w-full btn preset-tonal-surface">
-            <Trash2 size={16} />
+          <button
+            onclick={() => (openDeleteModal = true)}
+            type="button"
+            class="w-full btn preset-tonal-surface"
+          >
+            {#if $deleteMutation.isPending}
+              <LoaderCircle class="animate-spin" />
+            {:else}
+              <Trash2 size={16} />
+            {/if}
             Delete
           </button>
         </div>
@@ -67,6 +118,9 @@
 
 <p>{data.location.description}</p>
 
+{#if $deleteMutation.isError}
+  <p class="mt-2 text-error-500">{$deleteMutation.error.message}</p>
+{/if}
 <p class="mt-5">Add a location log to get started.</p>
 
 <button type="button" class="btn mt-2 preset-filled-primary-500">


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/locations/[slug]` endpoint and `deleteLocation` DB query with user-scoped authorization
- Wires up a confirmation modal (`DeleteLocationModal`) on the location detail page before executing the delete, then redirects to `/dashboard`
- Extracts a shared `api` ky instance (`src/lib/http/client.ts`) and migrates `location.ts` and `search.ts` to use it; also fixes a URL bug in `fetchSearchLocations` (`/api/search?q` → `/api/search`)
- Disables TanStack Query retries globally for both queries and mutations

## Test plan

- [x] Navigate to a location detail page and open the action menu — confirm the Delete button opens the confirmation modal
- [x] Cancel the modal — confirm the location is not deleted
- [x] Confirm the modal — confirm the location is deleted and the user is redirected to `/dashboard`
- [x] Attempt to delete a non-existent slug directly via `DELETE /api/locations/<slug>` — confirm 404 response
- [x] Verify search still works on the add location page

🤖 Generated with [Claude Code](https://claude.com/claude-code)