### PR TITLE
fix: guard dialog ref in effect and simplify confirm handler

### DIFF
--- a/src/lib/components/ConfirmModal.svelte
+++ b/src/lib/components/ConfirmModal.svelte
@@ -10,12 +10,12 @@
   let dialog: HTMLDialogElement;
 
   $effect(() => {
+    if (!dialog) {
+      return;
+    }
+
     open ? dialog.showModal() : dialog.close();
   });
-
-  function confirm() {
-    onConfirm?.();
-  }
 </script>
 
 <dialog
@@ -36,7 +36,7 @@
     <button
       type="button"
       class="btn preset-filled-primary-500"
-      onclick={confirm}>Confirm</button
+      onclick={onConfirm}>Confirm</button
     >
   </form>
 </dialog>


### PR DESCRIPTION
## Summary
- Add null guard for `dialog` ref in `$effect` to prevent errors before the element mounts
- Remove redundant `confirm()` wrapper — `onConfirm` is now called directly on click

## Test plan
- [x] Open a confirmation modal and confirm it triggers `onConfirm`
- [x] Verify no console errors on modal mount/unmount

🤖 Generated with [Claude Code](https://claude.com/claude-code)