### PR TITLE
fix: use dynamic env for Turso credentials

### DIFF
--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,4 +1,4 @@
-import { TURSO_AUTH_TOKEN, TURSO_DATABASE_URL } from "$env/dynamic/private";
+import { env } from "$env/dynamic/private";
 import { NODE_ENV } from "$env/static/private";
 import { drizzle } from "drizzle-orm/libsql";
 
@@ -6,8 +6,8 @@ import * as schema from "../../schema";
 
 const db = drizzle({
   connection: {
-    url: TURSO_DATABASE_URL,
-    authToken: NODE_ENV === "development" ? undefined : TURSO_AUTH_TOKEN,
+    url: env.TURSO_DATABASE_URL,
+    authToken: NODE_ENV === "development" ? undefined : env.TURSO_AUTH_TOKEN,
   },
   schema,
   casing: "snake_case",

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,4 +1,5 @@
-import { NODE_ENV, TURSO_AUTH_TOKEN, TURSO_DATABASE_URL } from "$env/static/private";
+import { TURSO_AUTH_TOKEN, TURSO_DATABASE_URL } from "$env/dynamic/private";
+import { NODE_ENV } from "$env/static/private";
 import { drizzle } from "drizzle-orm/libsql";
 
 import * as schema from "../../schema";


### PR DESCRIPTION
## Summary
- Move `TURSO_AUTH_TOKEN` and `TURSO_DATABASE_URL` from `$env/static/private` (build-time) to `$env/dynamic/private` (runtime)
- Fixes production 401 errors caused by token rotation not taking effect without a rebuild

## Test plan
- [ ] Merge and verify login works on production after Vercel redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)