### PR TITLE
chore: add temporary debug logs for Turso env vars

### DIFF
--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -4,6 +4,9 @@ import { drizzle } from "drizzle-orm/libsql";
 
 import * as schema from "../../schema";
 
+console.error("[db] TURSO_DATABASE_URL:", env.TURSO_DATABASE_URL);
+console.error("[db] TURSO_AUTH_TOKEN prefix:", env.TURSO_AUTH_TOKEN?.slice(0, 20));
+
 const db = drizzle({
   connection: {
     url: env.TURSO_DATABASE_URL,

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -4,15 +4,16 @@ import { drizzle } from "drizzle-orm/libsql";
 
 import * as schema from "../../schema";
 
+const authToken = NODE_ENV === "development" ? undefined : env.TURSO_AUTH_TOKEN;
+console.error("[db] NODE_ENV:", NODE_ENV);
 console.error("[db] TURSO_DATABASE_URL:", env.TURSO_DATABASE_URL);
-console.error("[db] TURSO_AUTH_TOKEN prefix:", env.TURSO_AUTH_TOKEN?.slice(0, 20));
-console.error("[db] TURSO_AUTH_TOKEN length:", env.TURSO_AUTH_TOKEN?.length);
-console.error("[db] TURSO_AUTH_TOKEN trimmed length:", env.TURSO_AUTH_TOKEN?.trim().length);
+console.error("[db] authToken length:", authToken?.length);
+console.error("[db] authToken prefix:", authToken?.slice(0, 20));
 
 const db = drizzle({
   connection: {
     url: env.TURSO_DATABASE_URL,
-    authToken: NODE_ENV === "development" ? undefined : env.TURSO_AUTH_TOKEN,
+    authToken,
   },
   schema,
   casing: "snake_case",

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -6,6 +6,8 @@ import * as schema from "../../schema";
 
 console.error("[db] TURSO_DATABASE_URL:", env.TURSO_DATABASE_URL);
 console.error("[db] TURSO_AUTH_TOKEN prefix:", env.TURSO_AUTH_TOKEN?.slice(0, 20));
+console.error("[db] TURSO_AUTH_TOKEN length:", env.TURSO_AUTH_TOKEN?.length);
+console.error("[db] TURSO_AUTH_TOKEN trimmed length:", env.TURSO_AUTH_TOKEN?.trim().length);
 
 const db = drizzle({
   connection: {


### PR DESCRIPTION
## Summary
- Adds temporary `console.error` logs to check what values `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` have at runtime on Vercel
- To be reverted after diagnosing the 401 issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)