### PR TITLE
fix: redirect to root on session fetch error in hooks

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,9 +6,16 @@ import { redirect } from "@sveltejs/kit";
 import { svelteKitHandler } from "better-auth/svelte-kit";
 
 export const handle: Handle = async ({ event, resolve }) => {
-  const session = await auth.api.getSession({
-    headers: event.request.headers,
-  });
+  let session = null;
+
+  try {
+    session = await auth.api.getSession({
+      headers: event.request.headers,
+    });
+  } catch {
+    if (event.url.pathname !== "/")
+      redirect(302, "/");
+  }
 
   event.locals.session = session;
 


### PR DESCRIPTION
## Summary

- Wraps `auth.api.getSession()` in a `try/catch` block in `hooks.server.ts`
- On auth failure, redirects non-root paths to `/` instead of propagating an unhandled error
- Initializes `session` to `null` so `event.locals.session` is always assigned

## Test plan

- [ ] Sign in normally — session loads without issue
- [ ] Simulate an auth error (e.g. invalid/expired token) on a `/dashboard/**` route — should redirect to `/`
- [ ] Verify root path `/` is unaffected when a session error occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)