### PR TITLE
feat: add location log creation flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,10 @@ Migrations are generated and applied with `drizzle-kit` and stored in `src/lib/s
 
 - `GET /api/locations` — fetch the authenticated user's locations
 - `POST /api/locations` — create a location; handled by the `InsertLocation` service class which slugifies the name and retries on slug collisions (up to 3 attempts)
+- `GET /api/locations/[slug]` — fetch a single location by slug
+- `PUT /api/locations/[slug]` — update a location
+- `DELETE /api/locations/[slug]` — delete a location
+- `POST /api/locations/[slug]/logs` — create a location log entry
 - `GET /api/search?q=...` — proxy to Nominatim (OpenStreetMap geocoder) for location search
 
 ### State management pattern
@@ -97,7 +101,8 @@ Server service functions return `Response<T, E>` (defined in `src/lib/server/uti
 /                        — landing / sign-in
 /dashboard               — location list + map
 /dashboard/add           — add location form with draggable marker and Nominatim search
-/dashboard/location/[slug] — location detail (stub)
+/dashboard/location/[slug] — location detail
+/dashboard/location/[slug]/add — add location log form
 /sign-out                — triggers signOut
 /error                   — auth error redirect target
 /api/locations           — REST endpoint

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:fix": "eslint --fix"
   },
   "dependencies": {
+    "@internationalized/date": "^3.12.1",
     "@libsql/client": "^0.15.9",
     "@lucide/svelte": "^0.525.0",
     "@tanstack/svelte-form": "^1.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@internationalized/date':
+        specifier: ^3.12.1
+        version: 3.12.1
       '@libsql/client':
         specifier: ^0.15.9
         version: 0.15.9

--- a/src/lib/components/DatePicker.svelte
+++ b/src/lib/components/DatePicker.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import type { DateValue } from "@internationalized/date";
+  import { getLocalTimeZone } from "@internationalized/date";
+  import { ArrowLeft, ArrowRight, Calendar } from "@lucide/svelte";
+  import { DatePicker } from "bits-ui";
+
+  type Props = {
+    value?: DateValue;
+    label: string;
+    onchange: (timestamp: number) => void;
+    error: string;
+    name: string;
+  };
+
+  let {
+    value = $bindable(undefined),
+    label,
+    onchange,
+    error,
+    name,
+  }: Props = $props();
+
+  function onValueChange(value: DateValue | undefined) {
+    // eslint-disable-next-line antfu/if-newline
+    if (!value) return;
+
+    const date = value.toDate(getLocalTimeZone()).getTime();
+
+    onchange(date);
+  }
+</script>
+
+<DatePicker.Root
+  bind:value
+  {onValueChange}
+  weekdayFormat="short"
+  fixedWeeks={true}
+>
+  <div class="flex w-full flex-col gap-1.5">
+    <DatePicker.Label class="block select-none text-xs">
+      {label}
+    </DatePicker.Label>
+    <DatePicker.Input
+      class="flex items-center border border-surface-200-800 p-1 rounded"
+    >
+      {#snippet children({ segments })}
+        {#each segments as { part, value }, i (part + i)}
+          <div class="inline-block select-none">
+            {#if part === "literal"}
+              <DatePicker.Segment {part} class="p-1">
+                {value}
+              </DatePicker.Segment>
+            {:else}
+              <DatePicker.Segment {part} class="rounded px-1 py-1">
+                {value}
+              </DatePicker.Segment>
+            {/if}
+          </div>
+        {/each}
+        <DatePicker.Trigger
+          class="ml-auto inline-flex size-8 items-center justify-center rounded-[5px] transition-all"
+        >
+          <Calendar size={16} />
+        </DatePicker.Trigger>
+      {/snippet}
+    </DatePicker.Input>
+    <DatePicker.Content sideOffset={6} class="z-50">
+      <DatePicker.Calendar
+        class="rounded-[15px] border p-[22px] bg-surface-800"
+      >
+        {#snippet children({ months, weekdays })}
+          <DatePicker.Header class="flex items-center justify-between">
+            <DatePicker.PrevButton
+              class="inline-flex size-10 items-center justify-center transition-all active:scale-[0.98]"
+            >
+              <ArrowLeft size={16} />
+            </DatePicker.PrevButton>
+            <DatePicker.Heading class="text-[15px] font-medium" />
+            <DatePicker.NextButton
+              class="inline-flex size-10 items-center justify-center transition-all active:scale-[0.98]"
+            >
+              <ArrowRight size={16} />
+            </DatePicker.NextButton>
+          </DatePicker.Header>
+          <div
+            class="flex flex-col space-y-4 pt-4 sm:flex-row sm:space-x-4 sm:space-y-0"
+          >
+            {#each months as month (month.value)}
+              <DatePicker.Grid
+                class="w-full border-collapse select-none space-y-1"
+              >
+                <DatePicker.GridHead>
+                  <DatePicker.GridRow class="mb-1 flex w-full justify-between">
+                    {#each weekdays as day (day)}
+                      <DatePicker.HeadCell
+                        class="text-surface-900 font-normal! w-10 rounded-md text-xs"
+                      >
+                        <div>{day.slice(0, 2)}</div>
+                      </DatePicker.HeadCell>
+                    {/each}
+                  </DatePicker.GridRow>
+                </DatePicker.GridHead>
+                <DatePicker.GridBody>
+                  {#each month.weeks as weekDates (weekDates)}
+                    <DatePicker.GridRow class="flex w-full">
+                      {#each weekDates as date (date)}
+                        <DatePicker.Cell
+                          {date}
+                          month={month.value}
+                          class="p-0! relative size-10 text-center text-sm"
+                        >
+                          <DatePicker.Day
+                            class="hover:border-surface-900 data-selected:bg-surface-900 data-disabled:text-surface-900 data-selected:text-primary-500 data-unavailable:text-surface-900 data-disabled:pointer-events-none data-outside-month:pointer-events-none data-selected:font-medium data-unavailable:line-through group relative inline-flex size-10 items-center justify-center whitespace-nowrap border border-transparent bg-transparent p-0 text-sm font-normal transition-all"
+                          >
+                            <div
+                              class="group-data-today:block absolute top-[5px] hidden size-1 rounded-full transition-all"
+                            ></div>
+                            {date.day}
+                          </DatePicker.Day>
+                        </DatePicker.Cell>
+                      {/each}
+                    </DatePicker.GridRow>
+                  {/each}
+                </DatePicker.GridBody>
+              </DatePicker.Grid>
+            {/each}
+          </div>
+        {/snippet}
+      </DatePicker.Calendar>
+    </DatePicker.Content>
+    {#if error}
+      <span id={`${name}-error`} class="text-xs text-error-500">
+        {error}
+      </span>
+    {/if}
+  </div>
+</DatePicker.Root>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,4 +5,5 @@ export const NOMINATIM_URL = "https://nominatim.openstreetmap.org";
 export const SIDE_BY_SIDE_ROUTES = new Set([
   "/dashboard/add",
   "/dashboard/location/[slug]/edit",
+  "/dashboard/location/[slug]/add",
 ]);

--- a/src/lib/http/location-log.ts
+++ b/src/lib/http/location-log.ts
@@ -1,0 +1,6 @@
+import type { LocationLogInsertData } from "$lib/types";
+import { api } from "./client";
+
+export async function fetchCreateLocationLog(log: LocationLogInsertData, slug: string) {
+  return await api.post(`/api/locations/${slug}/logs`, { json: log }).json();
+}

--- a/src/lib/schema/location-log-image.ts
+++ b/src/lib/schema/location-log-image.ts
@@ -1,5 +1,6 @@
-import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { relations } from "drizzle-orm";
 
+import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { user } from "./auth";
 import { locationLog } from "./location-log";
 
@@ -11,3 +12,10 @@ export const locationLogImage = sqliteTable("locationLogImage", {
   createdAt: int().notNull().$default(() => Date.now()),
   updatedAt: int().notNull().$default(() => Date.now()).$onUpdate(() => Date.now()),
 });
+
+export const locationLogImageRelations = relations(locationLogImage, ({ one }) => ({
+  locationLog: one(locationLog, {
+    fields: [locationLogImage.locationLogId],
+    references: [locationLog.id],
+  }),
+}));

--- a/src/lib/schema/location-log.ts
+++ b/src/lib/schema/location-log.ts
@@ -1,7 +1,11 @@
-import { int, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { relations } from "drizzle-orm";
 
+import { int, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { createInsertSchema } from "drizzle-valibot";
+import * as v from "valibot";
 import { user } from "./auth";
 import { location } from "./location";
+import { locationLogImage } from "./location-log-image";
 
 export const locationLog = sqliteTable("locationLog", {
   id: int().primaryKey({ autoIncrement: true }),
@@ -16,3 +20,59 @@ export const locationLog = sqliteTable("locationLog", {
   createdAt: int().notNull().$default(() => Date.now()),
   updatedAt: int().notNull().$default(() => Date.now()).$onUpdate(() => Date.now()),
 });
+
+export const locationLogRelations = relations(locationLog, ({ one, many }) => ({
+  location: one(location, {
+    fields: [locationLog.locationId],
+    references: [location.id],
+  }),
+  images: many(locationLogImage),
+}));
+
+export const LocationLogSchema = v.pipe(
+  v.omit(
+    createInsertSchema(locationLog, {
+      name: v.pipe(
+        v.string(),
+        v.nonEmpty("name cannot be empty"),
+        v.maxLength(100, "name cannot exceed 100 characters"),
+      ),
+      description: v.optional(
+        v.pipe(
+          v.string(),
+          v.maxLength(100, "description cannot exceed 100 characters"),
+        ),
+      ),
+      lat: v.pipe(
+        v.number(),
+        v.minValue(-90, "latitude must be at least -90"),
+        v.maxValue(90, "latitude must not exceed 90"),
+      ),
+      long: v.pipe(
+        v.number(),
+        v.minValue(-180, "longitude must be at least -180"),
+        v.maxValue(180, "longitude must not exceed 180",
+        ),
+      ),
+      startedAt: v.number(),
+      endedAt: v.number(),
+    }),
+    ["id", "userId", "locationId", "createdAt", "updatedAt"],
+  ),
+  v.forward(
+    v.partialCheck(
+      [["startedAt"], ["endedAt"]],
+      (input) => input.startedAt < input.endedAt,
+      "Start Date must be before End Date",
+    ),
+    ["startedAt"],
+  ),
+  v.forward(
+    v.partialCheck(
+      [["startedAt"], ["endedAt"]],
+      (input) => input.endedAt > input.startedAt,
+      "End Date must be after Start Date",
+    ),
+    ["endedAt"],
+  ),
+);

--- a/src/lib/server/db/queries/location-log.ts
+++ b/src/lib/server/db/queries/location-log.ts
@@ -1,0 +1,16 @@
+import type { LocationLogInsertData } from "$lib/types";
+import { locationLog } from "$lib/schema";
+
+import db from "$lib/server/db";
+
+export async function insertLocationLog(userId: number, locationId: number, log: LocationLogInsertData) {
+  const [newLog] = await db.insert(locationLog)
+    .values({
+      ...log,
+      userId,
+      locationId,
+    })
+    .returning();
+
+  return newLog;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type { LocationInsertSchema, LocationSelectSchema } from "$lib/schema/location";
+import type { LocationLogSchema } from "$lib/schema/location-log";
 import type { auth } from "$lib/server/auth";
 
 import type * as v from "valibot";
@@ -7,6 +8,7 @@ export type Session = Awaited<ReturnType<typeof auth.api.getSession>>;
 
 export type Location = v.InferInput<typeof LocationSelectSchema>;
 export type LocationInsertData = v.InferInput<typeof LocationInsertSchema>;
+export type LocationLogInsertData = v.InferInput<typeof LocationLogSchema>;
 
 export type MapPoint = Location & {
   to: string;

--- a/src/routes/api/locations/[slug]/logs/+server.ts
+++ b/src/routes/api/locations/[slug]/logs/+server.ts
@@ -1,0 +1,46 @@
+import type { RequestHandler } from "./$types";
+import { LocationLogSchema } from "$lib/schema";
+import { AuthenticatedRequestHandler } from "$lib/server/auth-request-handler";
+import { findLocation } from "$lib/server/db/queries/location";
+import { insertLocationLog } from "$lib/server/db/queries/location-log";
+import { formatValibotIssues } from "$lib/utils/valibot-format-error";
+import { json } from "@sveltejs/kit";
+import * as v from "valibot";
+
+export const POST: RequestHandler = AuthenticatedRequestHandler(async ({ request, locals, params }) => {
+  const body = await request.json();
+  const slug = params.slug;
+
+  const result = v.safeParse(LocationLogSchema, body);
+
+  if (!result.success) {
+    return json(formatValibotIssues(result.issues), {
+      status: 400,
+    });
+  }
+
+  const validatedData = result.output;
+  const userId = Number(locals.session!.user.id);
+
+  const location = await findLocation(userId, slug);
+
+  if (!location) {
+    return json({
+      msg: "Location not found",
+    }, {
+      status: 404,
+    });
+  }
+
+  try {
+    const newLog = await insertLocationLog(userId, location.id, validatedData);
+    return json({ log: newLog }, { status: 201 });
+  } catch (err: any) {
+    console.error(err);
+    return json({
+      msg: "Internal server error",
+    }, {
+      status: 500,
+    });
+  }
+});

--- a/src/routes/dashboard/location/[slug]/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/+page.svelte
@@ -42,6 +42,10 @@
     goto(`/dashboard/location/${data.location.slug}/edit`);
   }
 
+  function gotoAddLocationLog() {
+    goto(`/dashboard/location/${data.location.slug}/add`);
+  }
+
   async function deleteLocation() {
     try {
       await $deleteMutation.mutateAsync(data.location.slug);
@@ -120,7 +124,11 @@
 {/if}
 <p class="mt-5">Add a location log to get started.</p>
 
-<button type="button" class="btn mt-2 preset-filled-primary-500">
+<button
+  type="button"
+  onclick={gotoAddLocationLog}
+  class="btn mt-2 preset-filled-primary-500"
+>
   Add Location Log
   <MapPinPlus size={16} />
 </button>

--- a/src/routes/dashboard/location/[slug]/add/+page.server.ts
+++ b/src/routes/dashboard/location/[slug]/add/+page.server.ts
@@ -1,0 +1,21 @@
+import type { Location } from "$lib/types";
+import type { PageServerLoad } from "./$types";
+import { error } from "@sveltejs/kit";
+
+export const load: PageServerLoad = async ({ fetch, params }) => {
+  const slug = params.slug;
+
+  const response = await fetch(`/api/locations/${slug}`);
+
+  if (!response.ok) {
+    const body = await response.json();
+    error(response.status, body);
+  }
+
+  const data = await response.json();
+  const location = data.location as Location;
+
+  return {
+    location,
+  };
+};

--- a/src/routes/dashboard/location/[slug]/add/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/add/+page.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import type { LocationLogInsertData } from "$lib/types";
+  import type { DateValue } from "@internationalized/date";
+  import type { PageProps } from "./$types";
+  import { goto } from "$app/navigation";
+  import DatePicker from "$lib/components/DatePicker.svelte";
+  import FormField from "$lib/components/FormField.svelte";
+  import LocationFormBase from "$lib/components/LocationFormBase.svelte";
+  import { getMapContext } from "$lib/context/map";
+  import { fetchCreateLocationLog } from "$lib/http/location-log";
+  import { LocationLogSchema } from "$lib/schema";
+  import {
+    CalendarDate,
+    getLocalTimeZone,
+    today,
+  } from "@internationalized/date";
+  import { Plus } from "@lucide/svelte";
+  import { onMount } from "svelte";
+
+  const { data }: PageProps = $props();
+
+  const mapStore = getMapContext();
+
+  const initialValues = {
+    name: "",
+    description: "",
+    lat: 0,
+    long: 0,
+    startedAt: today(getLocalTimeZone()).toDate(getLocalTimeZone()).getTime(),
+    endedAt: today(getLocalTimeZone())
+      .add({ days: 1 })
+      .toDate(getLocalTimeZone())
+      .getTime(),
+  } as LocationLogInsertData;
+
+  function dateToDateValue(timestamp: number): DateValue {
+    const date = new Date(timestamp);
+
+    return new CalendarDate(
+      date.getFullYear(),
+      date.getMonth() + 1,
+      date.getDate(),
+    );
+  }
+
+  async function addLocationLog(log: LocationLogInsertData) {
+    await fetchCreateLocationLog(log, data.location.slug);
+  }
+
+  async function redirectToLocationPage() {
+    goto(`/dashboard/location/${data.location.slug}`);
+  }
+
+  onMount(() => {
+    mapStore.addMarker = { lat: data.location.lat, lng: data.location.long };
+    mapStore.showAddMarker = true;
+
+    return () => (mapStore.showAddMarker = false);
+  });
+</script>
+
+<div class="py-6 px-2">
+  <LocationFormBase
+    {initialValues}
+    schema={LocationLogSchema}
+    redirectOnCancel={`/dashboard/location/${data.location.slug}`}
+    redirectOnConfirm={`/dashboard/location/${data.location.slug}`}
+    confirmLabel="Add"
+    ConfirmIcon={Plus}
+    isPending={false}
+    onsubmit={addLocationLog}
+    onsubmitComplete={redirectToLocationPage}
+  >
+    {#snippet fields(form)}
+      <form.Field name="name">
+        {#snippet children(field: any)}
+          <FormField
+            label="Name"
+            name="name"
+            value={field.state.value}
+            errors={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+            oninput={(e) => {
+              const target = e.target as HTMLInputElement;
+              field.handleChange(target.value);
+            }}
+          />
+        {/snippet}
+      </form.Field>
+
+      <form.Field name="description">
+        {#snippet children(field: any)}
+          <FormField
+            label="Description"
+            type="textarea"
+            name="description"
+            value={field.state.value}
+            errors={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+            oninput={(e) => {
+              const target = e.target as HTMLTextAreaElement;
+              field.handleChange(target.value);
+            }}
+          />
+        {/snippet}
+      </form.Field>
+
+      <form.Field name="startedAt">
+        {#snippet children(field: any)}
+          <DatePicker
+            name="startedAt"
+            label="Started At"
+            value={dateToDateValue(field.state.value)}
+            onchange={field.handleChange}
+            error={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+          />
+        {/snippet}
+      </form.Field>
+
+      <form.Field name="endedAt">
+        {#snippet children(field: any)}
+          <DatePicker
+            name="endedAt"
+            label="Ended At"
+            value={dateToDateValue(field.state.value)}
+            onchange={field.handleChange}
+            error={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+          />
+        {/snippet}
+      </form.Field>
+    {/snippet}
+  </LocationFormBase>
+</div>


### PR DESCRIPTION
## Summary

- Add `DatePicker` component built on `bits-ui` and `@internationalized/date`
- Add full location log creation flow: schema, DB query, API route (`POST /api/locations/[slug]/logs`), and form page (`/dashboard/location/[slug]/add`)
- Wire "Add Location Log" button on the location detail page to the new route
- Update CLAUDE.md with missing API routes and routing structure


## Fix

#36 

## Test plan

- [ ] Navigate to a location detail page and click "Add Location Log"
- [ ] Fill in name, description, start date, and end date and submit
- [ ] Verify the log is created (check DB via `pnpm db:studio`)
- [ ] Submit with end date before start date and verify validation errors appear on both date fields
- [ ] Submit with empty name and verify error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)