### PR TITLE
feat: display location logs in location detail page and sidebar

### DIFF
--- a/src/lib/components/LocationNavItems.svelte
+++ b/src/lib/components/LocationNavItems.svelte
@@ -1,23 +1,65 @@
 <script lang="ts">
-  import type { Location } from "$lib/types";
+  import type { Location, SidebarItem } from "$lib/types";
   import NavItem from "$lib/components/NavItem.svelte";
 
-  import { ArrowLeft, Map } from "@lucide/svelte";
+  import { getMapContext } from "$lib/context/map";
+  import { ArrowLeft, Map, MapPin, Plus } from "@lucide/svelte";
 
   type Props = {
+    sidebarItems: SidebarItem[];
     location: Location | undefined;
   };
 
-  const { location }: Props = $props();
+  const { location, sidebarItems }: Props = $props();
+
+  const mapStore = getMapContext();
 </script>
 
 <NavItem href="/dashboard" label="Back to locations">
   <ArrowLeft />
 </NavItem>
 
-<NavItem
-  href={`/dashboard/location/${location?.slug}`}
-  label={location?.name ?? ""}
->
-  <Map />
-</NavItem>
+{#if location}
+  <NavItem
+    href={`/dashboard/location/${location.slug}`}
+    label={location?.name ?? ""}
+  >
+    <Map />
+  </NavItem>
+
+  <NavItem
+    href={`/dashboard/location/${location.slug}/edit`}
+    label="Edit Location"
+  >
+    <MapPin />
+  </NavItem>
+
+  <NavItem
+    href={`/dashboard/location/${location.slug}/add`}
+    label="Add Location Log"
+  >
+    <Plus />
+  </NavItem>
+{/if}
+
+{#if sidebarItems.length > 0}
+  <hr class="hr border-white" />
+{/if}
+
+{#each sidebarItems as item (item.id)}
+  <NavItem
+    href={item.mapPoint.to}
+    label={item.mapPoint.name}
+    onmouseenter={() => {
+      mapStore.selectedPoint = item.mapPoint;
+    }}
+    onmouseleave={() => {
+      mapStore.selectedPoint = undefined;
+    }}
+  >
+    {@const isHovered = mapStore.selectedPoint?.id === item.mapPoint.id}
+    <MapPin
+      class={["group-hover:fill-primary-500", isHovered && "fill-primary-500"]}
+    />
+  </NavItem>
+{/each}

--- a/src/lib/schema/location-log.ts
+++ b/src/lib/schema/location-log.ts
@@ -1,7 +1,7 @@
 import { relations } from "drizzle-orm";
 
 import { int, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import { createInsertSchema } from "drizzle-valibot";
+import { createInsertSchema, createSelectSchema } from "drizzle-valibot";
 import * as v from "valibot";
 import { user } from "./auth";
 import { location } from "./location";
@@ -76,3 +76,5 @@ export const LocationLogSchema = v.pipe(
     ["endedAt"],
   ),
 );
+
+export const LocationLogSelectSchema = createSelectSchema(locationLog);

--- a/src/lib/schema/location.ts
+++ b/src/lib/schema/location.ts
@@ -1,10 +1,12 @@
+import { relations } from "drizzle-orm";
+
 import { int, real, sqliteTable, text, unique } from "drizzle-orm/sqlite-core";
 
 import { createInsertSchema, createSelectSchema } from "drizzle-valibot";
 
 import * as v from "valibot";
-
 import { user } from "./auth";
+import { locationLog } from "./location-log";
 
 export const location = sqliteTable("location", {
   id: int().primaryKey({ autoIncrement: true }),
@@ -19,6 +21,12 @@ export const location = sqliteTable("location", {
 }, t => [
   unique().on(t.name, t.userId),
 ]);
+
+export const locationRelations = relations(location, ({ many }) => {
+  return {
+    locationLogs: many(locationLog),
+  };
+});
 
 export const LocationInsertSchema = v.omit(createInsertSchema(location, {
   name: v.pipe(

--- a/src/lib/server/db/queries/location.ts
+++ b/src/lib/server/db/queries/location.ts
@@ -27,6 +27,13 @@ export async function findLocation(userId: number, slug: string) {
       eq(location.userId, userId),
       eq(location.slug, slug),
     ),
+    with: {
+      locationLogs: {
+        orderBy(fields, operators) {
+          return operators.desc(fields.startedAt);
+        },
+      },
+    },
   });
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
 import type { LocationInsertSchema, LocationSelectSchema } from "$lib/schema/location";
-import type { LocationLogSchema } from "$lib/schema/location-log";
+import type { LocationLogSchema, LocationLogSelectSchema } from "$lib/schema/location-log";
 import type { auth } from "$lib/server/auth";
 
 import type * as v from "valibot";
@@ -7,10 +7,16 @@ import type * as v from "valibot";
 export type Session = Awaited<ReturnType<typeof auth.api.getSession>>;
 
 export type Location = v.InferInput<typeof LocationSelectSchema>;
+export type LocationLog = v.InferInput<typeof LocationLogSelectSchema>;
+
+export type LocationWithLogs = Location & {
+  locationLogs: LocationLog[];
+};
+
 export type LocationInsertData = v.InferInput<typeof LocationInsertSchema>;
 export type LocationLogInsertData = v.InferInput<typeof LocationLogSchema>;
 
-export type MapPoint = Location & {
+export type MapPoint = (Location | LocationLog) & {
   to: string;
 };
 

--- a/src/lib/utils/map.ts
+++ b/src/lib/utils/map.ts
@@ -1,6 +1,6 @@
-import type { Location, MapPoint } from "$lib/types";
+import type { Location, LocationLog, MapPoint } from "$lib/types";
 
-export function createMapPointFromLocation(location: Location, to: string): MapPoint {
+export function createMapPointFromLocation(location: Location | LocationLog, to: string): MapPoint {
   return {
     ...location,
     to,

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import type { Location, MapPoint, SidebarItem } from "$lib/types";
+  import type {
+    Location,
+    LocationWithLogs,
+    MapPoint,
+    SidebarItem,
+  } from "$lib/types";
   import type { LayoutProps } from "./$types";
 
   import { page } from "$app/state";
@@ -22,7 +27,7 @@
   let isExpanded = $state(true);
   const isSideBySide = $derived(SIDE_BY_SIDE_ROUTES.has(page.route.id ?? ""));
   const locations = $derived<Location[] | undefined>(page.data.locations);
-  const location = $derived<Location | undefined>(page.data.location);
+  const location = $derived<LocationWithLogs | undefined>(page.data.location);
 
   const navGroup = $derived.by(() => {
     const id = page.route.id ?? "";
@@ -41,26 +46,42 @@
   }
 
   const sidebarItems = $derived.by<SidebarItem[]>(() => {
-    if (navGroup !== "dashboard" || !locations) {
-      return [];
+    if (navGroup === "location" && location) {
+      return location.locationLogs.map((l) => ({
+        id: `item-${l.id}`,
+        mapPoint: createMapPointFromLocation(
+          l,
+          `/dashboard/location/${location.slug}/${l.id}`,
+        ),
+      }));
     }
 
-    return locations.map((l) => ({
-      id: `item-${l.slug}`,
-      mapPoint: createMapPointFromLocation(l, `/dashboard/location/${l.slug}`),
-    }));
+    if (navGroup === "dashboard" && locations && locations.length > 0) {
+      return locations.map((l) => ({
+        id: `item-${l.slug}`,
+        mapPoint: createMapPointFromLocation(
+          l,
+          `/dashboard/location/${l.slug}`,
+        ),
+      }));
+    }
+
+    return [];
   });
 
   const mapPoints = $derived.by<MapPoint[]>(() => {
     if (navGroup === "dashboard")
       return sidebarItems.map((item) => item.mapPoint);
+
     if (navGroup === "location" && location) {
-      return [
-        createMapPointFromLocation(
-          location,
-          `/dashboard/location/${location.slug}`,
-        ),
-      ];
+      const locationMapPoint = createMapPointFromLocation(
+        location,
+        `/dashboard/location/${location.slug}`,
+      );
+
+      return location.locationLogs.length > 0
+        ? sidebarItems.map((item) => item.mapPoint)
+        : [locationMapPoint];
     }
     return [];
   });
@@ -91,7 +112,7 @@
         {#if navGroup === "dashboard"}
           <DashboardNavItems {sidebarItems} />
         {:else if navGroup === "location"}
-          <LocationNavItems {location} />
+          <LocationNavItems {location} {sidebarItems} />
         {/if}
       {/snippet}
 

--- a/src/routes/dashboard/location/[slug]/+page.server.ts
+++ b/src/routes/dashboard/location/[slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import type { Location } from "$lib/types";
+import type { LocationWithLogs } from "$lib/types";
 import type { PageServerLoad } from "./$types";
 import { error } from "@sveltejs/kit";
 
@@ -13,7 +13,7 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
   }
 
   const data = await response.json();
-  const location = data.location as Location;
+  const location = data.location as LocationWithLogs;
 
   return {
     location,

--- a/src/routes/dashboard/location/[slug]/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/+page.svelte
@@ -2,8 +2,10 @@
   import type { PageProps } from "./$types";
   import { goto } from "$app/navigation";
   import DeleteLocationModal from "$lib/components/DeleteLocationModal.svelte";
-  import { fetchDeleteLocation } from "$lib/http/location";
 
+  import LocationCard from "$lib/components/LocationCard.svelte";
+  import { getMapContext } from "$lib/context/map";
+  import { fetchDeleteLocation } from "$lib/http/location";
   import {
     EllipsisVertical,
     MapPinPlus,
@@ -15,6 +17,8 @@
   import { HTTPError } from "ky";
 
   const { data }: PageProps = $props();
+
+  const mapStore = getMapContext();
 
   let open = $state(false);
   let openDeleteModal = $state(false);
@@ -117,18 +121,24 @@
   </DropdownMenu.Portal>
 </DropdownMenu.Root>
 
-<p>{data.location.description}</p>
+<p class="mb-2">{data.location.description}</p>
 
 {#if $deleteMutation.isError}
   <p class="mt-2 text-error-500">{$deleteMutation.error.message}</p>
 {/if}
-<p class="mt-5">Add a location log to get started.</p>
 
-<button
-  type="button"
-  onclick={gotoAddLocationLog}
-  class="btn mt-2 preset-filled-primary-500"
->
-  Add Location Log
-  <MapPinPlus size={16} />
-</button>
+{#if data.location.locationLogs.length === 0}
+  <p class="mt-5">Add a location log to get started.</p>
+  <button
+    type="button"
+    onclick={gotoAddLocationLog}
+    class="btn mt-2 preset-filled-primary-500"
+  >
+    Add Location Log
+    <MapPinPlus size={16} />
+  </button>
+{:else}
+  {#each mapStore.mapPoints() as point (point.id)}
+    <LocationCard {point} />
+  {/each}
+{/if}

--- a/src/routes/dashboard/location/[slug]/add/+page.server.ts
+++ b/src/routes/dashboard/location/[slug]/add/+page.server.ts
@@ -1,4 +1,4 @@
-import type { Location } from "$lib/types";
+import type { LocationWithLogs } from "$lib/types";
 import type { PageServerLoad } from "./$types";
 import { error } from "@sveltejs/kit";
 
@@ -13,7 +13,7 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
   }
 
   const data = await response.json();
-  const location = data.location as Location;
+  const location = data.location as LocationWithLogs;
 
   return {
     location,

--- a/src/routes/dashboard/location/[slug]/edit/+page.server.ts
+++ b/src/routes/dashboard/location/[slug]/edit/+page.server.ts
@@ -1,4 +1,4 @@
-import type { Location } from "$lib/types";
+import type { LocationWithLogs } from "$lib/types";
 import type { PageServerLoad } from "./$types";
 import { error } from "@sveltejs/kit";
 
@@ -13,7 +13,7 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
   }
 
   const data = await response.json();
-  const location = data.location as Location;
+  const location = data.location as LocationWithLogs;
 
   return {
     location,


### PR DESCRIPTION
## Summary

- Adds `LocationLog` and `LocationWithLogs` types; fetches logs alongside location data via Drizzle relation
- Shows location logs as sidebar nav items and map points when navigating a location detail page
- Renders `LocationCard` list on the detail page when logs exist; keeps the empty-state CTA when there are none

## Fix

#37 
#39
#38 

## Test plan

- [ ] Navigate to a location that has no logs — empty-state with "Add Location Log" button should appear
- [ ] Navigate to a location with logs — cards should render and map pins should show on the map
- [ ] Hover over a sidebar log item — corresponding map pin should highlight
- [ ] Sidebar should show Edit Location and Add Location Log nav links for every location detail route

🤖 Generated with [Claude Code](https://claude.com/claude-code)