### PR TITLE
feat: add location log edit flow

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,4 +6,5 @@ export const SIDE_BY_SIDE_ROUTES = new Set([
   "/dashboard/add",
   "/dashboard/location/[slug]/edit",
   "/dashboard/location/[slug]/add",
+  "/dashboard/location/[slug]/[id]/edit",
 ]);

--- a/src/lib/http/location-log.ts
+++ b/src/lib/http/location-log.ts
@@ -4,3 +4,7 @@ import { api } from "./client";
 export async function fetchCreateLocationLog(log: LocationLogInsertData, slug: string) {
   return await api.post(`/api/locations/${slug}/logs`, { json: log }).json();
 }
+
+export async function fetchUpdateLocationLog(log: LocationLogInsertData, slug: string, id: number) {
+  return await api.put(`/api/locations/${slug}/logs/${id}`, { json: log }).json();
+}

--- a/src/lib/server/db/queries/location-log.ts
+++ b/src/lib/server/db/queries/location-log.ts
@@ -24,3 +24,17 @@ export async function findLocationLog(userId: number, locationId: number) {
     ),
   });
 }
+
+export async function updateLocationLog(userId: number, locationId: number, data: LocationLogInsertData) {
+  const [updatedLog] = await db.update(locationLog)
+    .set(data)
+    .where(
+      and(
+        eq(locationLog.id, locationId),
+        eq(locationLog.userId, userId),
+      ),
+    )
+    .returning();
+
+  return updatedLog;
+}

--- a/src/routes/api/locations/[slug]/logs/[id]/+server.ts
+++ b/src/routes/api/locations/[slug]/logs/[id]/+server.ts
@@ -1,7 +1,11 @@
 import type { RequestHandler } from "./$types";
+import { LocationLogSchema } from "$lib/schema";
 import { AuthenticatedRequestHandler } from "$lib/server/auth-request-handler";
-import { findLocationLog } from "$lib/server/db/queries/location-log";
+import { findLocationLog, updateLocationLog } from "$lib/server/db/queries/location-log";
+
+import { formatValibotIssues } from "$lib/utils/valibot-format-error";
 import { json } from "@sveltejs/kit";
+import * as v from "valibot";
 
 export const GET: RequestHandler = AuthenticatedRequestHandler(async ({ locals, params }) => {
   const id = params.id;
@@ -23,6 +27,45 @@ export const GET: RequestHandler = AuthenticatedRequestHandler(async ({ locals, 
     });
   } catch (err: any) {
     console.error(err);
+    return json({
+      msg: "Internal server error",
+    }, {
+      status: 500,
+    });
+  }
+});
+
+export const PUT: RequestHandler = AuthenticatedRequestHandler(async ({ request, locals, params }) => {
+  const id = params.id;
+  const userId = Number(locals.session!.user.id);
+  const body = await request.json();
+
+  const result = v.safeParse(LocationLogSchema, body);
+
+  if (!result.success) {
+    return json(formatValibotIssues(result.issues), {
+      status: 400,
+    });
+  }
+
+  const validatedData = result.output;
+
+  try {
+    const updatedLog = await updateLocationLog(userId, Number(id), validatedData);
+
+    if (!updatedLog) {
+      return json({
+        msg: "Log not found",
+      }, {
+        status: 404,
+      });
+    }
+
+    return json({
+      log: updatedLog,
+    });
+  }
+  catch {
     return json({
       msg: "Internal server error",
     }, {

--- a/src/routes/dashboard/location/[slug]/[id]/+layout.server.ts
+++ b/src/routes/dashboard/location/[slug]/[id]/+layout.server.ts
@@ -1,8 +1,8 @@
 import type { LocationLog } from "$lib/types";
-import type { PageServerLoad } from "./$types";
+import type { LayoutServerLoad } from "./$types";
 import { error } from "@sveltejs/kit";
 
-export const load: PageServerLoad = async ({ fetch, params }) => {
+export const load: LayoutServerLoad = async ({ fetch, params }) => {
   const slug = params.slug;
   const id = params.id;
 

--- a/src/routes/dashboard/location/[slug]/[id]/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/[id]/+page.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import type { DateValue } from "@internationalized/date";
-  import type { PageProps } from "./$types";
   import { goto } from "$app/navigation";
+  import { page } from "$app/state";
   import { CalendarDate } from "@internationalized/date";
   import { EllipsisVertical, PenLine, Trash2 } from "@lucide/svelte";
   import { DropdownMenu } from "bits-ui";
 
-  const { data }: PageProps = $props();
   let open = $state(false);
   let buttonEl = $state<HTMLButtonElement>();
 
@@ -21,18 +20,22 @@
   }
 
   function gotoLogEdit() {
-    goto(`/dashboard/location/${data.location.slug}/${data.log.id}/edit`);
+    goto(
+      `/dashboard/location/${page.data.location.slug}/${page.data.log.id}/edit`,
+    );
   }
 </script>
 
 <div>
   <p>
-    {dateToDateValue(data.log.startedAt)} / {dateToDateValue(data.log.endedAt)}
+    {dateToDateValue(page.data.log.startedAt)} / {dateToDateValue(
+      page.data.log.endedAt,
+    )}
   </p>
 </div>
 
 <div class="flex gap-2 items-center">
-  <h1 class="h5 truncate">{data.log.name}</h1>
+  <h1 class="h5 truncate">{page.data.log.name}</h1>
   <button
     bind:this={buttonEl}
     type="button"

--- a/src/routes/dashboard/location/[slug]/[id]/edit/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/[id]/edit/+page.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import type { LocationLogInsertData } from "$lib/types";
+  import type { DateValue } from "@internationalized/date";
+  import { goto } from "$app/navigation";
+  import { page } from "$app/state";
+  import DatePicker from "$lib/components/DatePicker.svelte";
+  import FormField from "$lib/components/FormField.svelte";
+  import LocationFormBase from "$lib/components/LocationFormBase.svelte";
+  import { getMapContext } from "$lib/context/map";
+  import { fetchUpdateLocationLog } from "$lib/http/location-log";
+  import { LocationLogSchema } from "$lib/schema";
+  import { CalendarDate } from "@internationalized/date";
+  import { MapPin } from "@lucide/svelte";
+  import { onMount } from "svelte";
+
+  const mapStore = getMapContext();
+
+  const initialValues = {
+    name: page.data.log.name,
+    description: page.data.log.description,
+    lat: page.data.log.lat,
+    long: page.data.log.long,
+    startedAt: page.data.log.startedAt,
+    endedAt: page.data.log.endedAt,
+  } as LocationLogInsertData;
+
+  function dateToDateValue(timestamp: number): DateValue {
+    const date = new Date(timestamp);
+
+    return new CalendarDate(
+      date.getFullYear(),
+      date.getMonth() + 1,
+      date.getDate(),
+    );
+  }
+
+  async function updateLog(log: LocationLogInsertData) {
+    await fetchUpdateLocationLog(
+      log,
+      page.data.location.slug,
+      page.data.log.id,
+    );
+  }
+
+  async function redirectToLogPage() {
+    goto(`/dashboard/location/${page.data.location.slug}/${page.data.log.id}`, {
+      invalidateAll: true,
+    });
+  }
+
+  onMount(() => {
+    mapStore.addMarker = {
+      lat: page.data.log.lat,
+      lng: page.data.log.long,
+    };
+    mapStore.showAddMarker = true;
+
+    return () => (mapStore.showAddMarker = false);
+  });
+</script>
+
+<div class="py-6 px-2">
+  <LocationFormBase
+    {initialValues}
+    schema={LocationLogSchema}
+    redirectOnCancel={`/dashboard/location/${page.data.location.slug}`}
+    redirectOnConfirm={`/dashboard/location/${page.data.location.slug}`}
+    confirmLabel="Update Log"
+    ConfirmIcon={MapPin}
+    isPending={false}
+    onsubmit={updateLog}
+    onsubmitComplete={redirectToLogPage}
+  >
+    {#snippet fields(form)}
+      <form.Field name="name">
+        {#snippet children(field: any)}
+          <FormField
+            label="Name"
+            name="name"
+            value={field.state.value}
+            errors={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+            oninput={(e) => {
+              const target = e.target as HTMLInputElement;
+              field.handleChange(target.value);
+            }}
+          />
+        {/snippet}
+      </form.Field>
+
+      <form.Field name="description">
+        {#snippet children(field: any)}
+          <FormField
+            label="Description"
+            type="textarea"
+            name="description"
+            value={field.state.value}
+            errors={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+            oninput={(e) => {
+              const target = e.target as HTMLTextAreaElement;
+              field.handleChange(target.value);
+            }}
+          />
+        {/snippet}
+      </form.Field>
+
+      <form.Field name="startedAt">
+        {#snippet children(field: any)}
+          <DatePicker
+            name="startedAt"
+            label="Started At"
+            value={dateToDateValue(field.state.value)}
+            onchange={field.handleChange}
+            error={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+          />
+        {/snippet}
+      </form.Field>
+
+      <form.Field name="endedAt">
+        {#snippet children(field: any)}
+          <DatePicker
+            name="endedAt"
+            label="Ended At"
+            value={dateToDateValue(field.state.value)}
+            onchange={field.handleChange}
+            error={field.state.meta.errors
+              .map((e: any) => e.message)
+              .join(", ")}
+          />
+        {/snippet}
+      </form.Field>
+    {/snippet}
+  </LocationFormBase>
+</div>

--- a/src/routes/dashboard/location/[slug]/add/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/add/+page.svelte
@@ -48,7 +48,9 @@
   }
 
   async function redirectToLocationPage() {
-    goto(`/dashboard/location/${data.location.slug}`);
+    goto(`/dashboard/location/${data.location.slug}`, {
+      invalidateAll: true,
+    });
   }
 
   onMount(() => {


### PR DESCRIPTION
## Summary

- Add `PUT /api/locations/[slug]/logs/[id]` endpoint with valibot validation and ownership check
- Add `updateLocationLog` DB query and `fetchUpdateLocationLog` HTTP helper
- Add edit page at `/dashboard/location/[slug]/[id]/edit` pre-populated with existing log data
- Promote `+page.server.ts` to `+layout.server.ts` under `[id]/` so log data is shared with the edit child route
- Fix missing `invalidateAll: true` on redirect after log creation

## Fix

#41 

## Test plan

- [x] Navigate to a location log detail page and click Edit
- [x] Verify the form is pre-populated with the existing log's data and map marker is positioned correctly
- [x] Submit the form and confirm the log detail page reflects the updated values
- [x] Verify editing a non-existent log returns 404
- [x] Verify unsaved changes modal appears when navigating away mid-edit
- [x] Verify creating a new log redirects and shows the new entry without a hard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)