### PR TITLE
feat: add location log delete flow

### DIFF
--- a/src/lib/http/location-log.ts
+++ b/src/lib/http/location-log.ts
@@ -8,3 +8,7 @@ export async function fetchCreateLocationLog(log: LocationLogInsertData, slug: s
 export async function fetchUpdateLocationLog(log: LocationLogInsertData, slug: string, id: number) {
   return await api.put(`/api/locations/${slug}/logs/${id}`, { json: log }).json();
 }
+
+export async function fetchDeleteLocationLog(slug: string, id: number) {
+  return await api.delete(`/api/locations/${slug}/logs/${id}`).json();
+}

--- a/src/lib/server/db/queries/location-log.ts
+++ b/src/lib/server/db/queries/location-log.ts
@@ -38,3 +38,16 @@ export async function updateLocationLog(userId: number, locationId: number, data
 
   return updatedLog;
 }
+
+export async function deleteLocationLog(userId: number, locationId: number) {
+  const [deletedLog] = await db.delete(locationLog)
+    .where(
+      and(
+        eq(locationLog.id, locationId),
+        eq(locationLog.userId, userId),
+      ),
+    )
+    .returning();
+
+  return deletedLog;
+}

--- a/src/routes/api/locations/[slug]/logs/[id]/+server.ts
+++ b/src/routes/api/locations/[slug]/logs/[id]/+server.ts
@@ -1,17 +1,29 @@
 import type { RequestHandler } from "./$types";
 import { LocationLogSchema } from "$lib/schema";
 import { AuthenticatedRequestHandler } from "$lib/server/auth-request-handler";
-import { findLocationLog, updateLocationLog } from "$lib/server/db/queries/location-log";
+import { findLocation } from "$lib/server/db/queries/location";
 
+import { deleteLocationLog, findLocationLog, updateLocationLog } from "$lib/server/db/queries/location-log";
 import { formatValibotIssues } from "$lib/utils/valibot-format-error";
 import { json } from "@sveltejs/kit";
 import * as v from "valibot";
 
 export const GET: RequestHandler = AuthenticatedRequestHandler(async ({ locals, params }) => {
   const id = params.id;
+  const slug = params.slug;
   const userId = Number(locals.session!.user.id);
 
   try {
+    const location = await findLocation(userId, slug);
+
+    if (!location) {
+      return json({
+        msg: "Location not found",
+      }, {
+        status: 404,
+      });
+    }
+
     const log = await findLocationLog(userId, Number(id));
 
     if (!log) {
@@ -37,6 +49,7 @@ export const GET: RequestHandler = AuthenticatedRequestHandler(async ({ locals, 
 
 export const PUT: RequestHandler = AuthenticatedRequestHandler(async ({ request, locals, params }) => {
   const id = params.id;
+  const slug = params.slug;
   const userId = Number(locals.session!.user.id);
   const body = await request.json();
 
@@ -51,6 +64,16 @@ export const PUT: RequestHandler = AuthenticatedRequestHandler(async ({ request,
   const validatedData = result.output;
 
   try {
+    const location = await findLocation(userId, slug);
+
+    if (!location) {
+      return json({
+        msg: "Location not found",
+      }, {
+        status: 404,
+      });
+    }
+
     const updatedLog = await updateLocationLog(userId, Number(id), validatedData);
 
     if (!updatedLog) {
@@ -66,6 +89,45 @@ export const PUT: RequestHandler = AuthenticatedRequestHandler(async ({ request,
     });
   }
   catch {
+    return json({
+      msg: "Internal server error",
+    }, {
+      status: 500,
+    });
+  }
+});
+
+export const DELETE: RequestHandler = AuthenticatedRequestHandler(async ({ locals, params }) => {
+  const id = params.id;
+  const slug = params.slug;
+  const userId = Number(locals.session!.user.id);
+
+  try {
+    const location = await findLocation(userId, slug);
+
+    if (!location) {
+      return json({
+        msg: "Location not found",
+      }, {
+        status: 404,
+      });
+    }
+
+    const log = await deleteLocationLog(userId, Number(id));
+
+    if (!log) {
+      return json({
+        msg: "Log not found",
+      }, {
+        status: 404,
+      });
+    }
+
+    return json({
+      log,
+    });
+  } catch (err: any) {
+    console.error(err);
     return json({
       msg: "Internal server error",
     }, {

--- a/src/routes/dashboard/location/[slug]/[id]/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/[id]/+page.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
+  import type { LocationLog } from "$lib/types";
   import type { DateValue } from "@internationalized/date";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
+  import { fetchDeleteLocationLog } from "$lib/http/location-log";
   import { CalendarDate } from "@internationalized/date";
-  import { EllipsisVertical, PenLine, Trash2 } from "@lucide/svelte";
+  import {
+    EllipsisVertical,
+    LoaderCircle,
+    PenLine,
+    Trash2,
+  } from "@lucide/svelte";
+  import { createMutation } from "@tanstack/svelte-query";
   import { DropdownMenu } from "bits-ui";
+  import { HTTPError } from "ky";
 
   let open = $state(false);
   let buttonEl = $state<HTMLButtonElement>();
@@ -17,6 +26,38 @@
       date.getMonth() + 1,
       date.getDate(),
     );
+  }
+  const deleteMutation = createMutation({
+    mutationKey: ["location-log", page.data.log.id],
+    mutationFn: async ({ slug, logId }: { slug: string; logId: number }) => {
+      try {
+        const data = (await fetchDeleteLocationLog(slug, logId)) as { log: LocationLog };
+
+        return data;
+      } catch (error) {
+        if (error instanceof HTTPError && error.response.status === 404) {
+          const result = (await error.response.json()) as { msg: string };
+          throw new Error(result.msg);
+        }
+
+        throw new Error("Unknown error");
+      }
+    },
+  });
+
+  async function deleteLog() {
+    try {
+      await $deleteMutation.mutateAsync({
+        slug: page.data.location.slug,
+        logId: page.data.log.id,
+      });
+
+      goto(`/dashboard/location/${page.data.location.slug}`, {
+        invalidateAll: true,
+      });
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   function gotoLogEdit() {
@@ -57,12 +98,18 @@
       >
         <div class="w-full">
           <button
-            onclick={() => {}}
+            onclick={deleteLog}
             type="button"
             class="w-full btn preset-tonal-surface"
+            disabled={$deleteMutation.isPending}
           >
-            <Trash2 size={16} />
-            Delete
+            {#if $deleteMutation.isPending}
+              <LoaderCircle size={16} />
+              Deleting...
+            {:else}
+              <Trash2 size={16} />
+              Delete
+            {/if}
           </button>
         </div>
       </DropdownMenu.Item>


### PR DESCRIPTION
## Summary

- Add `deleteLocationLog` DB query with ownership enforcement
- Add `fetchDeleteLocationLog` HTTP helper
- Add `DELETE /api/locations/[slug]/logs/[id]` endpoint with location ownership check and 404 handling
- Wire up delete mutation in log detail page with pending state and redirect on success
- Also adds location ownership check to existing GET and PUT handlers

## Fix

#42 

## Test plan

- [x] Open a location log detail page and click Delete
- [x] Verify the button shows a loading spinner while deleting
- [x] Confirm successful delete redirects to the location page and the log no longer appears
- [x] Verify deleting a non-existent log returns 404
- [x] Verify a user cannot delete another user's log

🤖 Generated with [Claude Code](https://claude.com/claude-code)