### PR TITLE
chore: add SeaweedFS docker-compose for local S3 dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,12 @@ GITHUB_CLIENT_SECRET=
 
 VERCEL_URL=
 
+# SeaweedFS S3 gateway (local dev via docker-compose up)
+# Create a user and access/secret key in the admin UI at http://localhost:23646/object-store/users
+S3_ENDPOINT=http://127.0.0.1:8333
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+S3_REGION=
+S3_BUCKET=
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ vite.config.ts.timestamp-*
 
 # DB local
 local*
+
+# SeaweedFS data
+seaweedfs/data
+seaweedfs/admin-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  seaweedfs:
+    image: chrislusf/seaweedfs:latest
+    container_name: seaweedfs
+    command: >
+      server
+      -dir=/data
+      -ip.bind=0.0.0.0
+      -filer
+      -s3
+    ports:
+      - "9333:9333" # master UI / API
+      - "19333:19333" # master gRPC
+      - "8082:8080" # volume server (8080 is used locally by Turso)
+      - "8888:8888" # filer UI / API
+      - "18888:18888" # filer gRPC
+      - "8333:8333" # S3 API
+    volumes:
+      - ./seaweedfs/data:/data
+    networks:
+      - seaweedfs
+
+  seaweedfs-admin:
+    image: chrislusf/seaweedfs:latest
+    container_name: seaweedfs-admin
+    command: admin -masters=seaweedfs:9333 -port=23646 -dataDir=/data
+    depends_on:
+      - seaweedfs
+    ports:
+      - "23646:23646" # Admin web UI (create/manage S3 buckets here)
+    volumes:
+      - ./seaweedfs/admin-data:/data
+    networks:
+      - seaweedfs
+
+networks:
+  seaweedfs:


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` to run SeaweedFS (filer + S3 gateway + admin UI) locally for object storage.
- S3 gateway starts with no baked-in identities; each setup creates its own access/secret key via the admin UI (`http://localhost:23646/object-store/users`).
- Add `S3_*` env vars to `.env.example` and ignore SeaweedFS data dirs in `.gitignore`.

## Test plan
- [x] `docker-compose up` brings up `seaweedfs` and `seaweedfs-admin` without errors
- [x] Create an S3 user/key via admin UI at `http://localhost:23646/object-store/users`
- [x] Verify S3 API at `http://127.0.0.1:8333` accepts requests with the generated key