### PR TITLE
feat: show image gallery on location log detail page

### DIFF
--- a/src/lib/components/ImagesPreview.svelte
+++ b/src/lib/components/ImagesPreview.svelte
@@ -11,7 +11,7 @@
   const { image, action }: ImagesPreviewProps = $props();
 </script>
 
-<div class="card preset-filled-surface-100-900 h-40 w-64">
+<div class="card preset-filled-surface-100-900 h-40 w-64 min-w-64">
   <a
     href={`${PUBLIC_S3_BUCKET_URL}/${image.key}`}
     class="block size-full p-2"

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -145,7 +145,7 @@
       "flex-1 grid",
       isSideBySide
         ? "grid-cols-[400px_auto]"
-        : "grid-cols-1 grid-rows-[30%_70%]",
+        : "grid-cols-1 grid-rows-[32%_68%]",
     ]}
   >
     <div class="p-1 overflow-y-auto">

--- a/src/routes/dashboard/location/[slug]/[id]/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/[id]/+page.svelte
@@ -3,10 +3,13 @@
   import type { DateValue } from "@internationalized/date";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
+  import ImageGallery from "$lib/components/ImageGallery.svelte";
+  import ImagePreview from "$lib/components/ImagesPreview.svelte";
   import { fetchDeleteLocationLog } from "$lib/http/location-log";
   import { CalendarDate } from "@internationalized/date";
   import {
     EllipsisVertical,
+    Images,
     LoaderCircle,
     PenLine,
     Trash2,
@@ -31,7 +34,9 @@
     mutationKey: ["location-log", page.data.log.id],
     mutationFn: async ({ slug, logId }: { slug: string; logId: number }) => {
       try {
-        const data = (await fetchDeleteLocationLog(slug, logId)) as { log: LocationLog };
+        const data = (await fetchDeleteLocationLog(slug, logId)) as {
+          log: LocationLog;
+        };
 
         return data;
       } catch (error) {
@@ -85,6 +90,26 @@
   >
     <EllipsisVertical />
   </button>
+</div>
+
+<div class="mt-2 w-full">
+  {#if page.data.log.images.length}
+    <ImageGallery>
+      {#each page.data.log.images as image (image.id)}
+        <ImagePreview {image} />
+      {/each}
+    </ImageGallery>
+  {:else}
+    <div class="mt-6">
+      <a
+        class="btn preset-filled-primary-500"
+        href={`/dashboard/location/${page.data.location.slug}/${page.data.log.id}/images`}
+      >
+        <Images />
+        Manage Images
+      </a>
+    </div>
+  {/if}
 </div>
 
 <DropdownMenu.Root bind:open>

--- a/src/routes/dashboard/location/[slug]/[id]/images/+page.svelte
+++ b/src/routes/dashboard/location/[slug]/[id]/images/+page.svelte
@@ -165,13 +165,13 @@
   isPending={$deleImageMutation.isPending}
 />
 
-<div class="p-3">
+<div class="p-3 overflow-y-hidden">
   <h1 class="h5 truncate mb-2">
     Manage "{page.data.log.name}" Images
   </h1>
 
   <div class="flex gap-2 w-full">
-    <div class="w-[250px]">
+    <div class="min-w-[250px] w-[250px]">
       <div
         class="relative h-28 bg-surface-500 mb-1 flex items-center justify-center p-1"
       >


### PR DESCRIPTION
## Summary
- Show an image gallery inline on the location log detail page when images exist, otherwise a "Manage Images" CTA
- Minor layout fixes: image preview min-width, dashboard grid row split, images page min-width/overflow

## Test plan
- [x] Open a log with existing images and confirm the gallery renders correctly
- [x] Open a log with no images and confirm the "Manage Images" CTA links to the images page
- [x] Verify dashboard layout still looks correct in stacked (non-side-by-side) mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)